### PR TITLE
ISSUE:8 - A bit more database and container cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,22 +79,26 @@ pnpm docker:dev:clean       # Clean everything
 ./scripts/docker-dev.sh rebuild     # Rebuild containers
 ```
 
-### Option 2: Local Development
+### Option 2: Local Development (Recommended for macOS)
 
-Run services locally without Docker:
+Run backend locally with databases in Docker for best hot-reload experience:
 
 ```bash
 # Install dependencies
 pnpm install
 
+# Start only databases via Docker
+docker compose up -d postgres redis
+
 # Set up environment
 cp apps/backend/.env.example apps/backend/.env
-# Edit .env with your local database/redis configuration
+# Edit .env with your configuration
 
-# Start PostgreSQL and Redis (via Docker or local install)
-# Then run the dev server
+# Run the dev server locally
 pnpm dev
 ```
+
+> **Note**: Hot reload works better when running the backend locally on macOS due to Docker volume file-watching limitations. See [Database docs](./docs/DATABASE.md#hot-reload-in-docker-macos) for details.
 
 > **Prerequisites:**
 >

--- a/apps/backend/nest-cli.json
+++ b/apps/backend/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "tsConfigPath": "tsconfig.json"
+    "tsConfigPath": "tsconfig.json",
+    "watchAssets": true
   }
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "dev": "NODE_NO_WARNINGS=1 nest start --watch -c nest-cli.json",
+    "dev:docker": "NODE_NO_WARNINGS=1 TSC_WATCHFILE=UseFsEventsWithFallbackDynamicPolling nest start --watch -c nest-cli.json",
     "build": "nest build -c nest-cli.json",
     "start": "node dist/main.js",
     "lint": "eslint .",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,7 +21,7 @@ services:
       # Prevent node_modules from being overwritten
       - /app/node_modules
       - /app/apps/backend/node_modules
-    command: pnpm --filter @matrix-academy/backend dev
+    command: pnpm --filter @matrix-academy/backend dev:docker
 
   # PostgreSQL with exposed logs for debugging
   postgres:

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -117,6 +117,24 @@ If migrations fail:
 3. Review TypeORM logs (`DATABASE_LOGGING=true`)
 4. Check for conflicting schema changes
 
+### Docker Compose Environment Switching
+
+When switching between production (`docker-compose.yml`) and development (`docker-compose.dev.yml`) configurations:
+
+1. **Password mismatch**: Production uses `matrix_password`, dev uses `dev_password`
+2. **Clean volumes** when switching: `docker compose down -v`
+3. **Rebuild containers** after switching: `docker compose up -d --build`
+
+### Hot Reload in Docker (macOS)
+
+**Known Limitation**: File system events don't propagate reliably through Docker volumes on macOS.
+
+**Workaround Options**:
+
+1. **Recommended for active development**: Run backend locally with `pnpm dev` and only databases in Docker
+2. **Docker-only development**: Manually restart backend container after code changes: `docker compose restart backend`
+3. **Use polling**: The `dev:docker` script attempts to use file polling, but results may vary
+
 ## Development Workflow
 
 1. Start PostgreSQL (via Docker Compose or locally)


### PR DESCRIPTION
  For this current ticket (issue-8):

  1. apps/backend/package.json - Added dev:docker script with polling
  2. apps/backend/nest-cli.json - Added watchAssets: true
  3. docker-compose.dev.yml - Updated to use dev:docker command
  4. docs/DATABASE.md - Added troubleshooting sections for Docker issues and hot reload
  5. README.md - Updated Option 2 to recommend local development for macOS

  All acceptance criteria met. Ready to commit when you are!