### PR TITLE
docs: apply academy spec boundary normalization

### DIFF
--- a/docs/openspec-boundary-map.md
+++ b/docs/openspec-boundary-map.md
@@ -1,0 +1,47 @@
+# OpenSpec Boundary Map
+
+This document records the ownership decisions applied by `normalize-academy-spec-boundaries`.
+
+## Capability Ownership
+
+| Shared behavior | Authoritative capability | Delegating surfaces |
+| --- | --- | --- |
+| Data export, account erasure, cookie preferences, consent persistence, privacy request state, and accessible privacy feedback | `academy-privacy-controls` | `academy-landing`, `academy-profile`, footer/legal entry points, authenticated settings surfaces |
+| Global color, typography, geometry, motion, backgrounds, decorative treatment, and iconography | `academy-visual-design` | All public and authenticated Academy surfaces |
+| Reusable UI primitive variants, local component state, accessibility, and component styling | `academy-design-system-components` | All screen specs that compose buttons, cards, forms, tabs, dialogs, tooltips, progress indicators, toasts, and navigation links |
+| Screen registry, protected route access, shell chrome, shell navigation, theme coordination, and shell side effects | `academy-shell` | `academy-dashboard`, `academy-catalog`, `academy-mission-log`, `academy-story`, `academy-lesson-challenge`, `academy-progression`, `academy-profile`, `academy-certificate` |
+| Authentication entry, form validation, session lifecycle, recovery, and abuse controls | `academy-auth-entry` | `academy-landing`, billing plan-intent entry, protected-route redirects |
+| Plan intent, checkout, subscription lifecycle, billing management, and entitlement checks | `academy-billing-access` | `academy-landing`, `academy-auth-entry`, content surfaces that require entitlement gates |
+| Catalog search/filter/enrollment surface state and offering cards | `academy-catalog` | Dashboard catalog previews, shell navigation, billing entitlement checks |
+| Dashboard summary state, resume mission, telemetry, and mission-log preview presentation | `academy-dashboard` | Shell navigation, progression values, mission-log preview data |
+| Mission-log grouping, transmission read state, category/tabs, and message actions | `academy-mission-log` | Dashboard preview, shell notification entry points |
+| Narrative beat rendering, branch choice state, checkpoints, rewinds, story map, and story persistence | `academy-story` | Landing preview, lesson challenge transitions, progression updates |
+| Coding challenge briefing, editor drafts, sandbox execution, test output, mentor behavior, and challenge completion | `academy-lesson-challenge` | Story challenge entry points, progression award updates |
+| Clearance ladder, XP, achievements, award integrity, and derived progression state | `academy-progression` | Dashboard telemetry, story telemetry, lesson completion, certificate eligibility |
+| Certificate presentation, sharing, verification, issuance, revocation display, and certificate privacy | `academy-certificate` | Progression completion-record navigation, public verification pages |
+| Learner identity editing, callsign, bio, avatar selection, terminal preferences, and profile persistence | `academy-profile` | Shell identity block, privacy-control entry points, theme preference coordination |
+
+## Duplicate Ownership Audit
+
+The baseline specs previously mixed ownership in these areas:
+
+| Area | Resolution |
+| --- | --- |
+| Landing privacy actions duplicated data export, erasure confirmation, cookie category, cancellation, and save behavior | Landing now owns only public footer entry points and delegates privacy behavior to `academy-privacy-controls`. |
+| Public and app surfaces repeated global visual direction | Surface specs now carry responsibility boundaries that refer global styling to `academy-visual-design`; surface specs may still define local layout and content exceptions. |
+| Screen specs referenced app-shell state directly | Screen specs now define whether they render inside or outside the shell, while `academy-shell` owns route selection, protected access, shell chrome, theme coordination, and side effects. |
+| Component specs could be interpreted as owning routing, persistence, validation, or network work | `academy-design-system-components` explicitly owns reusable primitive behavior only; consumers supply app-level behavior through props or composition. |
+| Progression, certificate, dashboard, story, lesson, and billing specs all mention learner state changes | Progression owns award integrity and derived progression state; certificates own completion-record presentation and verification; feature surfaces delegate shared state updates to the authoritative owner. |
+
+## Volatile Literal Classification
+
+| Literal or content pattern | Classification | Owner or follow-up |
+| --- | --- | --- |
+| Landing hero metrics such as story-path count, challenge count, and learner participation count | Data-source-driven content | `academy-landing` displays configured product metrics; data source contract can be specified with implementation work. |
+| Public pricing labels, plan names, and prices | Contractual until billing changes | `academy-billing-access` owns plan intent and subscription semantics; `academy-landing` owns public pricing display. |
+| Feature-card names, hero positioning copy, story preview labels, and CTA labels | Example/product copy | Surface specs can keep these as current product copy, but changes should be reviewed as content/product decisions. |
+| Story preview narrative from The Broken Pipeline | Mockup content | `academy-landing` owns public preview presentation; `academy-story` owns canonical narrative path data. |
+| Compliance badge labels such as GDPR, CCPA, and WCAG 2.2 AA | Contractual display labels, not legal-policy text | `academy-landing` owns badge display; legal policy content remains out of scope. |
+| Visual token names, color roles, grid sizes, glow treatment, and typography roles | Contractual design-system language | `academy-visual-design` owns global visual rules and should be changed by visual-design deltas. |
+| Shell screen IDs such as `landing`, `auth`, `dashboard`, `catalog`, `log`, `story`, `lesson`, `progression`, `profile`, and `certificate` | Contractual routing vocabulary | `academy-shell` owns the screen registry and protected route behavior. |
+| XP, clearance, achievement, completion-record, and certificate values shown in examples | Data-source-driven content | `academy-progression` and `academy-certificate` own derived state and presentation boundaries. |

--- a/openspec/changes/normalize-academy-spec-boundaries/tasks.md
+++ b/openspec/changes/normalize-academy-spec-boundaries/tasks.md
@@ -1,28 +1,28 @@
 ## 1. Boundary Audit
 
-- [ ] 1.1 Review all current `openspec/specs/academy-*` files and mark requirements that duplicate privacy, visual design, shell routing, component, billing, progression, certificate, story, lesson, dashboard, mission-log, catalog, auth, or profile ownership.
-- [ ] 1.2 Create a capability ownership map that identifies the authoritative owner and allowed delegating surfaces for each shared behavior.
-- [ ] 1.3 Identify hard-coded volatile literals in baseline specs and classify each as contractual, example copy, mockup content, or data-source-driven content.
+- [x] 1.1 Review all current `openspec/specs/academy-*` files and mark requirements that duplicate privacy, visual design, shell routing, component, billing, progression, certificate, story, lesson, dashboard, mission-log, catalog, auth, or profile ownership.
+- [x] 1.2 Create a capability ownership map that identifies the authoritative owner and allowed delegating surfaces for each shared behavior.
+- [x] 1.3 Identify hard-coded volatile literals in baseline specs and classify each as contractual, example copy, mockup content, or data-source-driven content.
 
 ## 2. Shared Capability Normalization
 
-- [ ] 2.1 Update `academy-privacy-controls` to own the complete data export, erasure, cookie preference, verification, consent persistence, request-state, and feedback accessibility contract.
-- [ ] 2.2 Update `academy-visual-design` to own global color, typography, geometry, motion, background, decorative treatment, and iconography rules.
-- [ ] 2.3 Update `academy-design-system-components` to own reusable primitive behavior, accessibility, variants, and component styling while excluding app-level routing, persistence, and backend behavior.
-- [ ] 2.4 Update `academy-shell` to own screen registry, protected route access, app chrome, shell navigation, theme coordination, and shell side effects.
+- [x] 2.1 Update `academy-privacy-controls` to own the complete data export, erasure, cookie preference, verification, consent persistence, request-state, and feedback accessibility contract.
+- [x] 2.2 Update `academy-visual-design` to own global color, typography, geometry, motion, background, decorative treatment, and iconography rules.
+- [x] 2.3 Update `academy-design-system-components` to own reusable primitive behavior, accessibility, variants, and component styling while excluding app-level routing, persistence, and backend behavior.
+- [x] 2.4 Update `academy-shell` to own screen registry, protected route access, app chrome, shell navigation, theme coordination, and shell side effects.
 
 ## 3. Surface Capability Normalization
 
-- [ ] 3.1 Update `academy-landing` to keep public presentation, CTA, pricing-section display, footer entry points, and delegation while removing duplicated privacy and global visual internals.
-- [ ] 3.2 Update `academy-auth-entry` and `academy-billing-access` so authentication owns account entry/session behavior and billing owns plan intent, checkout, subscriptions, and entitlements.
-- [ ] 3.3 Update `academy-catalog`, `academy-dashboard`, and `academy-mission-log` so each owns its own surface state while deriving or delegating shared behavior to the authoritative capability.
-- [ ] 3.4 Update `academy-story` and `academy-lesson-challenge` so story owns narrative/branch/checkpoint state and lesson challenge owns coding challenge execution, drafts, mentor, and sandbox behavior.
-- [ ] 3.5 Update `academy-progression` and `academy-certificate` so progression owns award integrity and derived progression while certificate owns record presentation, sharing, verification, and certificate privacy.
-- [ ] 3.6 Update `academy-profile` so profile owns learner profile editing and preferences while delegating erasure, credential verification, and shell theme application.
+- [x] 3.1 Update `academy-landing` to keep public presentation, CTA, pricing-section display, footer entry points, and delegation while removing duplicated privacy and global visual internals.
+- [x] 3.2 Update `academy-auth-entry` and `academy-billing-access` so authentication owns account entry/session behavior and billing owns plan intent, checkout, subscriptions, and entitlements.
+- [x] 3.3 Update `academy-catalog`, `academy-dashboard`, and `academy-mission-log` so each owns its own surface state while deriving or delegating shared behavior to the authoritative capability.
+- [x] 3.4 Update `academy-story` and `academy-lesson-challenge` so story owns narrative/branch/checkpoint state and lesson challenge owns coding challenge execution, drafts, mentor, and sandbox behavior.
+- [x] 3.5 Update `academy-progression` and `academy-certificate` so progression owns award integrity and derived progression while certificate owns record presentation, sharing, verification, and certificate privacy.
+- [x] 3.6 Update `academy-profile` so profile owns learner profile editing and preferences while delegating erasure, credential verification, and shell theme application.
 
 ## 4. Validation
 
-- [ ] 4.1 Run `openspec validate normalize-academy-spec-boundaries --strict`.
-- [ ] 4.2 Run `openspec validate --specs --strict` after applying baseline spec edits.
-- [ ] 4.3 Review the resulting specs for duplicated requirements and unresolved ownership conflicts.
-- [ ] 4.4 Confirm no frontend, backend, API, database, or infrastructure implementation changes are included in this normalization change.
+- [x] 4.1 Run `openspec validate normalize-academy-spec-boundaries --strict`.
+- [x] 4.2 Run `openspec validate --specs --strict` after applying baseline spec edits.
+- [x] 4.3 Review the resulting specs for duplicated requirements and unresolved ownership conflicts.
+- [x] 4.4 Confirm no frontend, backend, API, database, or infrastructure implementation changes are included in this normalization change.

--- a/openspec/specs/academy-auth-entry/spec.md
+++ b/openspec/specs/academy-auth-entry/spec.md
@@ -299,3 +299,23 @@ GIVEN a learner is temporarily locked out because of failed attempts
 WHEN the learner starts access-key recovery
 THEN the system allows the recovery flow subject to its own abuse controls
 AND does not bypass account verification.
+
+### Requirement: Auth Entry Responsibility Boundary
+The auth-entry capability SHALL own authentication screen presentation, form modes, field validation, submission state, session lifecycle entry behavior, access-key recovery, and authentication abuse feedback while delegating plan checkout, entitlement, and app-shell protected routing to their owning capabilities.
+
+#### Scenario: Plan intent is consumed but not owned
+- **GIVEN** the authentication screen receives a plan intent from landing or billing access
+- **WHEN** the user completes enrollment
+- **THEN** auth-entry carries the intent through account creation
+- **AND** billing-access owns checkout, entitlement, and subscription behavior.
+
+#### Scenario: Protected route return is shell-owned
+- **GIVEN** an unauthenticated learner is redirected to authentication from a protected route
+- **WHEN** authentication succeeds
+- **THEN** auth-entry reports successful authentication
+- **AND** academy-shell owns return-destination resolution.
+
+#### Scenario: Auth visuals follow global design
+- **GIVEN** auth-entry specifies authentication screen styling
+- **WHEN** global colors, typography, geometry, or motion are applied
+- **THEN** auth-entry follows academy-visual-design rather than redefining global visual rules.

--- a/openspec/specs/academy-billing-access/spec.md
+++ b/openspec/specs/academy-billing-access/spec.md
@@ -140,3 +140,24 @@ GIVEN billing management cannot be opened
 WHEN the learner activates a manage-billing action
 THEN the system displays a retryable error
 AND provides a support path.
+
+### Requirement: Billing Access Responsibility Boundary
+The billing-access capability SHALL own plan intent, checkout, entitlement enforcement, subscription lifecycle, and billing management while delegating authentication screen fields, session lifecycle, and general route rendering to auth-entry and shell.
+
+#### Scenario: Authentication owns account entry fields
+- **GIVEN** a billing flow requires the user to sign in or enroll
+- **WHEN** the authentication screen opens
+- **THEN** billing-access passes plan intent
+- **AND** auth-entry owns form fields, validation, submission state, and session creation.
+
+#### Scenario: Entitlements are authoritative for protected paid content
+- **GIVEN** a learner attempts to access paid content
+- **WHEN** access is evaluated
+- **THEN** billing-access owns subscription and entitlement state
+- **AND** content surfaces only display the resulting allowed or locked state.
+
+#### Scenario: Billing management stays outside content screens
+- **GIVEN** a learner opens billing management
+- **WHEN** billing account details or payment operations are required
+- **THEN** billing-access owns the billing management flow
+- **AND** Academy content screens do not expose payment details directly.

--- a/openspec/specs/academy-catalog/spec.md
+++ b/openspec/specs/academy-catalog/spec.md
@@ -385,3 +385,24 @@ GIVEN an offering requires a higher clearance level
 WHEN the learner attempts to access the offering
 THEN the system prevents access
 AND explains the required clearance level.
+
+### Requirement: Catalog Responsibility Boundary
+The catalog capability SHALL own offering discovery, filters, offering cards, catalog request state, catalog enrollment actions, and access-state display while delegating entitlement authority, story progression, and lesson execution to their owning capabilities.
+
+#### Scenario: Catalog displays entitlement results
+- **GIVEN** an offering requires paid access or clearance
+- **WHEN** the catalog renders the offering
+- **THEN** catalog displays the locked or available state
+- **AND** billing-access and progression remain authoritative for entitlement and clearance rules.
+
+#### Scenario: Catalog starts but does not own story progress
+- **GIVEN** a learner starts or resumes a story offering from catalog
+- **WHEN** navigation begins
+- **THEN** catalog initiates the route
+- **AND** academy-story owns checkpoints, branch state, and story progression.
+
+#### Scenario: Catalog starts but does not own lesson execution
+- **GIVEN** a learner opens a challenge offering from catalog
+- **WHEN** navigation begins
+- **THEN** catalog initiates the route
+- **AND** academy-lesson-challenge owns test execution, draft safety, and sandbox behavior.

--- a/openspec/specs/academy-certificate/spec.md
+++ b/openspec/specs/academy-certificate/spec.md
@@ -211,3 +211,23 @@ GIVEN a public verification page is opened
 WHEN the completion record is valid
 THEN the system displays only approved public fields
 AND does not expose private learner profile, billing, challenge submissions, or story decision details.
+
+### Requirement: Certificate Responsibility Boundary
+The certificate capability SHALL own completion-record presentation, certificate metadata, sharing actions, PDF generation expectations, external verification, record access, and verification privacy while delegating progression award rules to progression.
+
+#### Scenario: Certificate uses progression-derived records
+- **GIVEN** a learner opens a certificate or completion record
+- **WHEN** the record is displayed
+- **THEN** academy-certificate owns certificate presentation and verification behavior
+- **AND** academy-progression remains authoritative for whether the completion was earned.
+
+#### Scenario: Certificate share actions stay certificate-owned
+- **GIVEN** the learner shares, downloads, or opens a credential-network action
+- **WHEN** the action executes
+- **THEN** academy-certificate owns the status, metadata, and failure behavior.
+
+#### Scenario: Public verification avoids exposing private progression data
+- **GIVEN** a public verification URL is opened
+- **WHEN** certificate data is displayed
+- **THEN** academy-certificate owns the public/private data boundary
+- **AND** does not expose unrelated learner progression details.

--- a/openspec/specs/academy-dashboard/spec.md
+++ b/openspec/specs/academy-dashboard/spec.md
@@ -182,3 +182,24 @@ AND shows a recoverable error only for the mission-log preview.
 GIVEN the mission-log preview is displayed
 WHEN the learner activates the preview heading or a log row destination
 THEN the system navigates to the mission log or the row's configured destination.
+
+### Requirement: Dashboard Responsibility Boundary
+The dashboard capability SHALL own dashboard presentation, resume prompts, summary panels, and preview cards while deriving data from the capabilities that own progression, catalog enrollment, story checkpoints, and mission-log transmissions.
+
+#### Scenario: Dashboard displays derived progression
+- **GIVEN** dashboard displays XP, clearance, streak, or path progress
+- **WHEN** progression data changes
+- **THEN** dashboard reflects the derived values
+- **AND** academy-progression remains authoritative for progression rules and event-backed changes.
+
+#### Scenario: Dashboard resume delegates destination behavior
+- **GIVEN** dashboard displays a resume mission action
+- **WHEN** the learner activates it
+- **THEN** dashboard initiates navigation
+- **AND** academy-story owns checkpoint restoration and branch state.
+
+#### Scenario: Dashboard mission-log preview delegates log behavior
+- **GIVEN** dashboard displays recent transmissions
+- **WHEN** the learner interacts with a transmission
+- **THEN** dashboard routes to the relevant destination
+- **AND** academy-mission-log owns read state, grouping, counts, and log persistence.

--- a/openspec/specs/academy-landing/spec.md
+++ b/openspec/specs/academy-landing/spec.md
@@ -87,9 +87,8 @@ THEN the system displays a secondary `Watch a branch play out` action.
 #### Scenario: Hero metrics
 GIVEN the landing hero is displayed
 WHEN the user views the metrics row
-THEN the system displays `27 STORY PATHS`
-AND displays `412 CHALLENGES`
-AND displays `8,900+ OPERATIVES`.
+THEN the system displays story path count, challenge count, and learner participation metrics from configured product metrics
+AND does not hard-code temporary mockup counts as contractual product values.
 
 #### Scenario: Hero background treatment
 GIVEN the landing hero is displayed
@@ -217,69 +216,6 @@ AND displays social icons
 AND displays all-systems-operational status
 AND displays copyright, license, and Kansas City location metadata.
 
-### Requirement: Data Export Request
-WHEN the user requests a data export from the landing footer,
-the system SHALL invoke the shared privacy-controls data export flow.
-
-#### Scenario: Request data export
-GIVEN the landing footer is displayed
-WHEN the user activates `Request my data`
-THEN the system starts the shared data export request flow.
-
-### Requirement: Account Deletion Request
-WHEN the user starts account deletion from the landing footer,
-the system SHALL invoke the shared account-erasure confirmation flow.
-
-#### Scenario: Open deletion dialog
-GIVEN the landing footer is displayed
-WHEN the user activates `Delete me`
-THEN the system opens the shared account-erasure confirmation dialog.
-
-#### Scenario: Cancel deletion
-GIVEN the deletion confirmation dialog is open
-WHEN the user activates `Keep my account`
-THEN the system closes the dialog
-AND does not schedule account deletion.
-
-#### Scenario: Confirm deletion
-GIVEN the deletion confirmation dialog is open
-WHEN the user activates `Yes - delete me`
-THEN the system closes the dialog
-AND schedules account deletion through the shared account-erasure flow.
-
-### Requirement: Cookie Preferences
-WHEN the user opens cookie preferences from the landing footer,
-the system SHALL invoke the shared cookie preferences flow.
-
-#### Scenario: Open cookie preferences
-GIVEN the landing footer is displayed
-WHEN the user activates `Cookie preferences`
-THEN the system opens the shared cookie preferences dialog.
-
-#### Scenario: Strictly necessary cookies
-GIVEN the cookie preferences dialog is open
-WHEN the cookie categories render
-THEN Strictly necessary is marked always on
-AND describes sessions, security, and saving the learner's place in the story.
-
-#### Scenario: Optional cookie categories
-GIVEN the cookie preferences dialog is open
-WHEN the cookie categories render
-THEN Analytics is displayed with an optional switch
-AND Marketing is displayed with an optional switch.
-
-#### Scenario: Cancel cookie preferences
-GIVEN the cookie preferences dialog is open
-WHEN the user activates `Cancel`
-THEN the system closes the dialog
-AND does not display the preferences-saved status message.
-
-#### Scenario: Save cookie preferences
-GIVEN the cookie preferences dialog is open
-WHEN the user activates `Save preferences`
-THEN the system closes the dialog
-AND displays a status message stating cookie preferences were saved for this terminal.
-
 ### Requirement: Public Compliance Badges
 WHEN the landing footer renders its bottom bar,
 the system SHALL display compliance badges for GDPR, CCPA, and WCAG 2.2 AA.
@@ -324,3 +260,24 @@ AND prevents navigation content from overlapping the hero or page content.
 GIVEN the landing page is displayed
 WHEN assistive technology navigates the page
 THEN the system exposes recognizable header, main, section, and footer landmarks.
+
+### Requirement: Landing Responsibility Boundary
+The landing capability SHALL own public landing presentation, marketing section structure, public calls to action, footer entry points, and delegation to shared capabilities without owning shared privacy-control, authentication, billing, shell, or global visual-design internals.
+
+#### Scenario: Privacy actions delegate to privacy controls
+- **GIVEN** the landing page exposes data export, account erasure, or cookie preference entry points
+- **WHEN** the user activates one of those entry points
+- **THEN** the landing page invokes the shared privacy-controls capability
+- **AND** does not define privacy request persistence, verification, consent, or erasure policy behavior itself.
+
+#### Scenario: Auth and billing actions remain entry points
+- **GIVEN** the landing page displays enrollment, sign-in, or plan call-to-action controls
+- **WHEN** the user activates one of those controls
+- **THEN** the landing page routes to authentication or plan intent capture
+- **AND** does not define authentication form validation, session lifecycle, checkout, entitlement, or subscription behavior itself.
+
+#### Scenario: Landing visual treatment references global design
+- **GIVEN** the landing page specifies visual treatment for public sections
+- **WHEN** the implementation applies colors, typography, geometry, motion, or decorative treatments
+- **THEN** the landing page follows the academy-visual-design capability
+- **AND** only specifies landing-specific layout or content exceptions.

--- a/openspec/specs/academy-lesson-challenge/spec.md
+++ b/openspec/specs/academy-lesson-challenge/spec.md
@@ -305,3 +305,24 @@ GIVEN a lesson action, test row, checklist row, or mentor chip is interactive
 WHEN hover or press styling is applied
 THEN the system changes color, fill, border, or opacity only
 AND does not lift, translate, or scale the element.
+
+### Requirement: Lesson Challenge Responsibility Boundary
+The lesson-challenge capability SHALL own coding challenge presentation, challenge drafts, test execution expectations, mentor interactions, sandbox safety, and challenge completion behavior while delegating story branch decisions and global progression rules to their owning capabilities.
+
+#### Scenario: Challenge receives story context
+- **GIVEN** a learner enters a challenge from a story branch
+- **WHEN** the challenge initializes
+- **THEN** lesson-challenge uses the provided story and attempt context
+- **AND** academy-story remains authoritative for branch choice and checkpoint state.
+
+#### Scenario: Challenge completion reports progression event
+- **GIVEN** a learner completes a challenge
+- **WHEN** XP, clearance, or achievements may change
+- **THEN** lesson-challenge records or emits the completion result
+- **AND** academy-progression owns derived progression and award integrity rules.
+
+#### Scenario: Challenge visual treatment references global design
+- **GIVEN** challenge panes specify terminal, test, mentor, or code styling
+- **WHEN** global colors, typography, geometry, or motion are applied
+- **THEN** lesson-challenge follows academy-visual-design
+- **AND** only defines challenge-specific presentation constraints.

--- a/openspec/specs/academy-mission-log/spec.md
+++ b/openspec/specs/academy-mission-log/spec.md
@@ -287,3 +287,22 @@ GIVEN more transmissions exist than the initial page size
 WHEN the mission log renders the first page
 THEN the system provides a way to load or navigate to additional transmissions
 AND keeps tab counts accurate for the full result set.
+
+### Requirement: Mission Log Responsibility Boundary
+The mission-log capability SHALL own transmissions, grouping, tabs, unread/read state, counts, empty states, log request state, and action routing entry points while delegating destination screen behavior to the target capability.
+
+#### Scenario: Mission log owns read state
+- **GIVEN** a transmission is displayed in mission log
+- **WHEN** the learner marks it read or marks all read
+- **THEN** mission-log owns persisted read state and count recalculation.
+
+#### Scenario: Mission log routes but does not own destinations
+- **GIVEN** a transmission has an action destination
+- **WHEN** the learner activates the action
+- **THEN** mission-log initiates navigation to the configured destination
+- **AND** the destination capability owns the resulting screen behavior.
+
+#### Scenario: Dashboard preview does not own mission log state
+- **GIVEN** another surface previews transmissions
+- **WHEN** the learner interacts with the preview
+- **THEN** mission-log remains authoritative for read state, grouping, counts, and log persistence.

--- a/openspec/specs/academy-privacy-controls/spec.md
+++ b/openspec/specs/academy-privacy-controls/spec.md
@@ -154,3 +154,21 @@ GIVEN a privacy dialog is open
 WHEN the user navigates by keyboard
 THEN focus remains within the dialog until it closes
 AND closing the dialog returns focus to the control that opened it.
+
+### Requirement: Privacy Controls Responsibility Boundary
+The privacy-controls capability SHALL be the authoritative owner for data export, account erasure, cookie preferences, consent persistence, privacy request state, verification requirements, and privacy feedback accessibility across public and authenticated Academy surfaces.
+
+#### Scenario: Public surface delegates privacy behavior
+- **GIVEN** a public surface exposes a privacy action
+- **WHEN** the user starts that action
+- **THEN** the shared privacy-controls capability owns the confirmation, request state, persistence, verification, and feedback behavior.
+
+#### Scenario: Authenticated surface delegates privacy behavior
+- **GIVEN** an authenticated surface exposes a privacy action
+- **WHEN** the learner starts that action
+- **THEN** the shared privacy-controls capability owns the confirmation, request state, persistence, verification, and feedback behavior.
+
+#### Scenario: Surface-specific copy does not alter privacy policy
+- **GIVEN** a surface describes a privacy action in its own words
+- **WHEN** the privacy flow executes
+- **THEN** the privacy-controls capability remains the source of truth for policy, consent, erasure, export, and accessibility requirements.

--- a/openspec/specs/academy-profile/spec.md
+++ b/openspec/specs/academy-profile/spec.md
@@ -225,3 +225,23 @@ GIVEN the learner uploads or selects a new avatar
 WHEN the avatar update flow validates the image
 THEN the system enforces configured file type, size, and safety constraints
 AND displays actionable errors for invalid avatar updates.
+
+### Requirement: Profile Responsibility Boundary
+The profile capability SHALL own learner profile presentation, editable identity fields, avatar entry points, terminal preferences, validation, profile persistence, and danger-zone entry points while delegating account erasure behavior to privacy controls.
+
+#### Scenario: Profile opens but does not own erasure
+- **GIVEN** the profile danger zone exposes account deletion
+- **WHEN** the learner starts deletion
+- **THEN** profile opens or routes to the shared erasure flow
+- **AND** academy-privacy-controls owns confirmation, verification, scheduling, cancellation, retention exceptions, and request failure behavior.
+
+#### Scenario: Theme preference coordinates with shell
+- **GIVEN** profile exposes a dark mode preference
+- **WHEN** the learner changes that preference
+- **THEN** profile owns preference presentation and persistence request
+- **AND** academy-shell owns document-level theme application and shell synchronization.
+
+#### Scenario: Profile does not own auth credential recovery
+- **GIVEN** profile exposes identity or email updates
+- **WHEN** authentication, re-verification, or credential recovery is required
+- **THEN** auth-entry or the relevant authentication capability owns credential verification behavior.

--- a/openspec/specs/academy-progression/spec.md
+++ b/openspec/specs/academy-progression/spec.md
@@ -176,3 +176,22 @@ GIVEN an authorized administrative workflow corrects learner progression
 WHEN the correction is applied
 THEN the system records the correction reason
 AND updates the learner-facing progression view from the corrected state.
+
+### Requirement: Progression Responsibility Boundary
+The progression capability SHALL own clearance, XP, achievements, completion navigation entry points, read-only progression display, and progression integrity while delegating certificate record presentation and issuance details to certificate.
+
+#### Scenario: Progression owns award integrity
+- **GIVEN** a lesson, challenge, story, or administrative action reports a completion event
+- **WHEN** XP, clearance, or achievement state may change
+- **THEN** academy-progression owns duplicate prevention, corrections, and derived progression values.
+
+#### Scenario: Completion record navigation delegates certificate details
+- **GIVEN** progression displays a completion record link
+- **WHEN** the learner opens the completion record
+- **THEN** progression initiates navigation
+- **AND** academy-certificate owns certificate presentation, sharing, verification, and access privacy.
+
+#### Scenario: Dashboard values derive from progression
+- **GIVEN** another surface displays XP, clearance, achievements, or progress summaries
+- **WHEN** progression state changes
+- **THEN** the other surface derives display from academy-progression rather than defining independent progression rules.

--- a/openspec/specs/academy-shell/spec.md
+++ b/openspec/specs/academy-shell/spec.md
@@ -303,3 +303,24 @@ THEN the system navigates to the dashboard screen.
 GIVEN the user is viewing the authentication screen
 WHEN the user activates the brand lockup
 THEN the system navigates to the landing screen.
+
+### Requirement: Shell Responsibility Boundary
+The shell capability SHALL own top-level screen resolution, protected route access, persistent app chrome, app navigation, theme coordination, and shell-level render side effects for in-app Academy surfaces.
+
+#### Scenario: Screen routing delegates to shell
+- **GIVEN** a capability needs to navigate to another Academy screen
+- **WHEN** the navigation targets an app-level screen identifier
+- **THEN** the capability invokes shell-owned navigation behavior
+- **AND** does not define independent screen registry or protected-route policy.
+
+#### Scenario: Public and auth screens bypass app chrome
+- **GIVEN** the active screen is public or authentication entry
+- **WHEN** the shell resolves screen context
+- **THEN** the shell owns whether app chrome is rendered
+- **AND** surface capabilities only define their own content.
+
+#### Scenario: Theme changes coordinate through shell
+- **GIVEN** a surface exposes theme preference controls
+- **WHEN** the learner changes the active theme
+- **THEN** the shell owns document-level theme application and synchronization rules
+- **AND** the surface owns only its local control presentation.

--- a/openspec/specs/academy-story/spec.md
+++ b/openspec/specs/academy-story/spec.md
@@ -335,3 +335,24 @@ AND prompts the learner to refresh the story state.
 GIVEN rewinding will discard a persisted branch choice for the checkpoint
 WHEN the learner activates `Rewind to checkpoint`
 THEN the system asks for confirmation before changing the persisted branch state.
+
+### Requirement: Story Responsibility Boundary
+The story capability SHALL own narrative rendering, branch prompts, branch selection, checkpoint rewind, media playback expectations, branch maps, objectives, story telemetry display, and challenge handoff while delegating challenge execution to lesson challenge.
+
+#### Scenario: Story owns branch decisions
+- **GIVEN** a learner reaches a story decision point
+- **WHEN** the learner selects or rewinds a branch
+- **THEN** academy-story owns branch persistence, conflict handling, and checkpoint state
+- **AND** other capabilities do not independently change that branch state.
+
+#### Scenario: Challenge handoff delegates execution
+- **GIVEN** a selected story branch opens a coding challenge
+- **WHEN** the learner enters the lesson challenge surface
+- **THEN** academy-story initializes or resumes the challenge attempt context
+- **AND** academy-lesson-challenge owns code edits, tests, mentor interactions, sandbox safety, and completion reward application.
+
+#### Scenario: Story visuals reference global design
+- **GIVEN** story specifies decision, narration, media, or branch-map treatments
+- **WHEN** global colors, motion, typography, or decorative rules apply
+- **THEN** academy-story follows academy-visual-design
+- **AND** only defines story-specific presentation patterns.

--- a/openspec/specs/academy-visual-design/spec.md
+++ b/openspec/specs/academy-visual-design/spec.md
@@ -186,3 +186,23 @@ AND does not use emoji, hand-authored decorative SVGs, or unapproved icon styles
 GIVEN an icon represents story paths, challenges, lessons, progression, clearance, adventure map, XP, or choices
 WHEN the icon is selected
 THEN the system uses the corresponding approved Lucide concept icon where available.
+
+### Requirement: Visual Design Responsibility Boundary
+The visual-design capability SHALL be the authoritative owner for Academy art direction, color tokens, typography roles, geometry, motion, background treatment, iconography rules, and global visual constraints used by screens and reusable components.
+
+#### Scenario: Screen specs reference global visual rules
+- **GIVEN** a screen capability describes colors, typography, motion, geometry, iconography, or decorative treatments
+- **WHEN** visual rules overlap with global Academy style
+- **THEN** the screen capability references the visual-design capability
+- **AND** does not redefine the global visual contract.
+
+#### Scenario: Component specs reference global visual rules
+- **GIVEN** a reusable component capability describes styling constraints
+- **WHEN** the styling constraint is global to Academy rather than component-specific
+- **THEN** the component capability references the visual-design capability
+- **AND** only defines component-specific states, variants, and accessibility behavior.
+
+#### Scenario: Volatile visual examples remain non-contractual
+- **GIVEN** a mockup or design handoff contains example values or content
+- **WHEN** those values are not explicitly required by the visual-design capability
+- **THEN** other capabilities treat them as examples rather than independent product contracts.


### PR DESCRIPTION
## Summary
- add a documented OpenSpec ownership and volatile-literal boundary map
- apply responsibility-boundary requirements across Academy baseline specs
- remove duplicated landing-owned privacy internals and make landing metrics data-source-driven
- mark normalize-academy-spec-boundaries tasks complete

## Verification
- openspec validate normalize-academy-spec-boundaries --strict
- openspec validate --specs --strict
- openspec validate --all --strict
- git diff --check

No frontend, backend, API, database, or infrastructure implementation files are included.