### PR TITLE
docs: propose academy monorepo structure

### DIFF
--- a/openspec/changes/define-academy-monorepo-application-structure/.openspec.yaml
+++ b/openspec/changes/define-academy-monorepo-application-structure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/define-academy-monorepo-application-structure/README.md
+++ b/openspec/changes/define-academy-monorepo-application-structure/README.md
@@ -1,0 +1,3 @@
+# define-academy-monorepo-application-structure
+
+Define the Presstronic Academy monorepo application, package, service, and infrastructure boundaries before implementation scaffolding.

--- a/openspec/changes/define-academy-monorepo-application-structure/design.md
+++ b/openspec/changes/define-academy-monorepo-application-structure/design.md
@@ -1,0 +1,82 @@
+## Context
+
+The repository already contains the intended top-level structure:
+
+- `apps/web`, `apps/admin`, `apps/api`, `apps/worker`, and `apps/gateway`
+- `packages/ui`, `packages/contracts`, `packages/eslint-config`, and `packages/tsconfig`
+- `services/code-runner`, `services/notifications`, and `services/billing`
+- `infra/docker`, `infra/compose`, and `infra/scripts`
+- `docs/` and `openspec/`
+
+This structure is directionally correct, but it needs an explicit OpenSpec contract before implementation scaffolding begins. The most important architectural risk is prematurely treating every planned service directory as an active microservice boundary. The project should start with a primary Spring Boot API and extract independently deployable services only when operational reasons exist.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define authoritative ownership for the repo's top-level application, package, service, infrastructure, docs, and spec directories.
+- Preserve the planned React learner app, React admin app, Spring Boot API, worker, and optional gateway shape.
+- Make strict TypeScript and ShadCN explicit for frontend application and shared UI work.
+- Keep REST as the primary contract style while allowing WebSockets and deferring GraphQL.
+- Distinguish active application boundaries from future independently deployable service placeholders.
+
+**Non-Goals:**
+
+- Do not scaffold React, Spring Boot, Gradle, Vite, ShadCN, Docker, or CI implementation files in this change.
+- Do not define API endpoints, OpenAPI schemas, database schemas, auth provider configuration, or deployment environments.
+- Do not split backend behavior into microservices without later service-specific proposals.
+- Do not decide whether `apps/gateway` is needed.
+
+## Decisions
+
+### Decision: Keep `apps/api` as the primary backend boundary
+
+`apps/api` should own the initial Spring Boot backend for REST APIs, WebSockets, authentication, and core Academy workflows. This avoids premature service extraction while still allowing internal modular design.
+
+Alternative considered: start immediately with `services/*` as active microservices. That would add deployment, observability, data ownership, and integration complexity before the product has implementation evidence for those splits.
+
+### Decision: Treat `services/*` as reserved independently deployable boundaries
+
+`services/code-runner`, `services/notifications`, and `services/billing` should remain placeholders until a later OpenSpec proposal justifies each extraction by isolation, scaling, operational, data, or vendor-integration needs.
+
+Alternative considered: remove `services/*` until needed. Keeping placeholders is useful because the likely future boundaries are already known, but the spec must prevent accidental implementation drift.
+
+### Decision: Keep `apps/gateway` optional and empty
+
+`apps/gateway` should remain deferred until routing, edge authorization, aggregation, or cross-service concerns cannot cleanly live in `apps/api` or infrastructure.
+
+Alternative considered: scaffold a gateway immediately. That would create another deployable surface before there is a concrete edge concern.
+
+### Decision: Put cross-application frontend reuse in `packages/ui`
+
+`packages/ui` should own shared ShadCN-based React components used by `apps/web` and `apps/admin`. App-specific screens, routing, and state stay in the consuming app.
+
+Alternative considered: duplicate UI components in each app. That would move faster for the first screen but would make design-system consistency and accessibility harder to maintain.
+
+### Decision: Put API contracts in `packages/contracts`
+
+`packages/contracts` should own OpenAPI specs, generated TypeScript clients, and shared schemas. REST remains the default contract style; WebSockets are allowed for live workflows; GraphQL is deferred until a later proposal proves it adds value.
+
+Alternative considered: generate clients independently inside each frontend app. That would couple each app to API contract generation details and increase drift risk.
+
+## Risks / Trade-offs
+
+- Reserved service directories may imply premature microservice work -> The capability explicitly requires later proposals before activating each service.
+- Shared UI may become too broad -> `packages/ui` owns reusable components only; app workflows remain in `apps/web` and `apps/admin`.
+- Contracts package could blur frontend/backend ownership -> `packages/contracts` owns schemas and generated clients, while endpoint behavior remains with API capability proposals.
+- Gateway may remain unused -> This is acceptable; the spec treats it as optional and deferred.
+
+## Migration Plan
+
+1. Review and accept this OpenSpec proposal.
+2. Apply the change by updating baseline specs and README guidance as needed.
+3. Create follow-up implementation proposals for frontend workspace scaffolding, Spring Boot API scaffolding, shared contracts, and local infrastructure.
+4. Keep `services/*` and `apps/gateway` empty until later proposals activate them.
+
+Rollback is simple while this remains a proposal: remove the change directory. After archive, revert the archive commit if the structure contract needs to be removed.
+
+## Open Questions
+
+- Should `apps/worker` initially be a Spring Boot application, a JVM module launched separately, or a later implementation detail under `apps/api` until asynchronous workload needs are clearer?
+- Should shared Java modules live under `packages/`, a future `libs/`, or inside `apps/api` until concrete reuse exists?
+- Should `packages/contracts` initially store hand-authored OpenAPI files, generated clients, or both in separate subdirectories?

--- a/openspec/changes/define-academy-monorepo-application-structure/proposal.md
+++ b/openspec/changes/define-academy-monorepo-application-structure/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Presstronic Academy has been reset around a planned monorepo, but the repository structure is currently documented only by placeholder directories and README notes. Before scaffolding React, Spring Boot, contracts, services, or infrastructure, the project needs an authoritative OpenSpec capability that defines which top-level areas own which responsibilities and which areas are intentionally deferred.
+
+## What Changes
+
+- Add a new `academy-monorepo-structure` capability that defines the repository ownership model for deployable applications, shared packages, independently deployable services, infrastructure, docs, and OpenSpec artifacts.
+- Specify `apps/web` and `apps/admin` as React, strict TypeScript, Vite, Tailwind CSS, and ShadCN applications.
+- Specify `apps/api` as the primary Spring Boot REST and WebSocket backend.
+- Specify `apps/worker` as the background job and orchestration application.
+- Keep `apps/gateway` optional and deferred until a concrete edge, routing, or aggregation concern exists.
+- Specify `packages/contracts`, `packages/ui`, `packages/eslint-config`, and `packages/tsconfig` as shared workspace packages with clear ownership.
+- Reserve `services/code-runner`, `services/notifications`, and `services/billing` for independently deployable services only after later proposals justify each split.
+- Make REST the primary API style, allow WebSockets for live workflows, and defer GraphQL until a later proposal proves a clear need.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-monorepo-structure`: Repository structure, workspace ownership, application boundaries, shared package boundaries, service maturity rules, and API style defaults.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affects future repository scaffolding under `apps/`, `packages/`, `services/`, and `infra/`.
+- Establishes planning constraints for React frontend, admin, Spring Boot backend, shared UI, contracts, and future service work.
+- Does not create or modify application implementation code in this proposal.
+- Does not decide final service extraction timing, deployment topology, database schemas, API endpoints, or UI implementation details.

--- a/openspec/changes/define-academy-monorepo-application-structure/specs/academy-monorepo-structure/spec.md
+++ b/openspec/changes/define-academy-monorepo-application-structure/specs/academy-monorepo-structure/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: Top-Level Workspace Ownership
+The repository SHALL use top-level directories with distinct ownership for deployable applications, shared packages, independently deployable services, infrastructure assets, documentation, and OpenSpec artifacts.
+
+#### Scenario: Repository ownership areas are present
+GIVEN the repository structure is prepared for implementation
+WHEN a contributor reviews the project root
+THEN `apps/` owns deployable application entry points
+AND `packages/` owns shared workspace packages
+AND `services/` owns future independently deployable backend services
+AND `infra/` owns infrastructure assets
+AND `docs/` owns product, architecture, and design documentation
+AND `openspec/` owns baseline specifications, active changes, and archived changes.
+
+#### Scenario: New top-level areas require justification
+GIVEN a future change proposes a new top-level directory
+WHEN the change is reviewed
+THEN the proposal identifies the ownership boundary that is not covered by the existing top-level areas
+AND avoids adding overlapping top-level directories for the same responsibility.
+
+### Requirement: Application Workspace Boundaries
+The repository SHALL treat `apps/web`, `apps/admin`, `apps/api`, `apps/worker`, and `apps/gateway` as deployable application workspaces with distinct maturity expectations.
+
+#### Scenario: Learner web application boundary
+GIVEN learner-facing frontend work is implemented
+WHEN the work belongs to the public or authenticated learner experience
+THEN it lives under `apps/web`
+AND uses React, strict TypeScript, Vite, Tailwind CSS, and ShadCN unless a later proposal changes the frontend stack.
+
+#### Scenario: Admin application boundary
+GIVEN admin or instructor frontend work is implemented
+WHEN the work belongs to operational, instructional, support, moderation, reporting, or administrative workflows
+THEN it lives under `apps/admin`
+AND uses React, strict TypeScript, Vite, Tailwind CSS, and ShadCN unless a later proposal changes the frontend stack.
+
+#### Scenario: Primary API application boundary
+GIVEN backend API work is implemented before a service-specific extraction is accepted
+WHEN the work exposes REST APIs, WebSocket workflows, authentication integration, or core Academy backend orchestration
+THEN it lives under `apps/api`
+AND uses Java Spring Boot as the primary backend application.
+
+#### Scenario: Worker application boundary
+GIVEN background work is implemented outside a request lifecycle
+WHEN the work performs async jobs, scheduled jobs, event processing, code-runner orchestration, email orchestration, or other background coordination
+THEN it lives under `apps/worker`
+AND does not create an independently deployable service boundary unless a later proposal justifies that split.
+
+#### Scenario: Gateway remains deferred
+GIVEN the repository contains `apps/gateway`
+WHEN no accepted proposal defines gateway routing, aggregation, edge authorization, or cross-service edge behavior
+THEN `apps/gateway` remains empty or placeholder-only
+AND application traffic continues to be owned by `apps/api` or infrastructure configuration.
+
+### Requirement: Shared Package Boundaries
+The repository SHALL use `packages/` for shared workspace packages that are consumed by applications without owning application workflows.
+
+#### Scenario: Shared UI package boundary
+GIVEN reusable frontend UI components are implemented for both learner and admin applications
+WHEN the components wrap or extend ShadCN primitives, shared Academy styling, accessibility behavior, or reusable component variants
+THEN they live under `packages/ui`
+AND app-specific screens, routes, data loading, and workflow state remain in `apps/web` or `apps/admin`.
+
+#### Scenario: Contracts package boundary
+GIVEN API contracts or generated frontend clients are introduced
+WHEN the contracts describe REST schemas, OpenAPI files, generated TypeScript clients, or shared validation schemas
+THEN they live under `packages/contracts`
+AND endpoint behavior remains owned by backend and product capability specs.
+
+#### Scenario: Shared frontend configuration boundary
+GIVEN frontend TypeScript or lint configuration is shared across workspaces
+WHEN the configuration is reusable across frontend applications or packages
+THEN TypeScript configuration lives under `packages/tsconfig`
+AND ESLint configuration lives under `packages/eslint-config`.
+
+### Requirement: Independently Deployable Service Maturity
+The repository SHALL reserve `services/` for backend capabilities that require independent deployment, scaling, isolation, data ownership, vendor integration, or operational ownership beyond the primary API.
+
+#### Scenario: Service placeholder is not an active boundary
+GIVEN a service directory exists under `services/`
+WHEN no accepted OpenSpec proposal activates that service
+THEN the directory remains placeholder-only
+AND production behavior is not implemented there.
+
+#### Scenario: Code-runner service activation
+GIVEN isolated code execution needs exceed what can safely be orchestrated from `apps/api` or `apps/worker`
+WHEN a later proposal activates `services/code-runner`
+THEN the proposal defines sandbox isolation, execution lifecycle, API contracts, observability, and failure behavior before implementation.
+
+#### Scenario: Notifications service activation
+GIVEN notification delivery needs independent scaling, delivery guarantees, provider integration, or operational ownership
+WHEN a later proposal activates `services/notifications`
+THEN the proposal defines message sources, delivery channels, retry behavior, observability, and ownership boundaries before implementation.
+
+#### Scenario: Billing service activation
+GIVEN billing integration needs independent deployment, provider isolation, compliance controls, or operational ownership outside `apps/api`
+WHEN a later proposal activates `services/billing`
+THEN the proposal defines billing contracts, entitlement synchronization, provider webhooks, observability, and failure behavior before implementation.
+
+### Requirement: API Style Defaults
+The repository SHALL use REST as the primary API style, allow WebSockets for live workflows, and defer GraphQL until a later proposal establishes a concrete need.
+
+#### Scenario: REST-first contract
+GIVEN frontend or external clients need backend data or commands
+WHEN API behavior is specified
+THEN REST endpoints and OpenAPI contracts are the default approach
+AND shared contract artifacts live under `packages/contracts`.
+
+#### Scenario: WebSocket workflow
+GIVEN a workflow needs live progress, streaming status, collaboration, notifications, or long-running job updates
+WHEN request-response REST polling is not sufficient
+THEN the proposal may specify WebSocket behavior
+AND defines connection lifecycle, authorization, events, retry behavior, and fallback behavior.
+
+#### Scenario: GraphQL remains deferred
+GIVEN a future change proposes GraphQL
+WHEN the proposal is reviewed
+THEN it identifies query composition, client data-shaping, or schema federation needs that REST and WebSockets do not satisfy
+AND defines how GraphQL coexists with existing REST contracts.
+
+### Requirement: Implementation Proposal Sequencing
+The repository SHALL separate structure approval from implementation scaffolding and SHALL require focused follow-up proposals for major implementation surfaces.
+
+#### Scenario: Structure proposal precedes scaffolding
+GIVEN this monorepo structure proposal is still active
+WHEN implementation work is planned
+THEN React, Spring Boot, contracts, service, infrastructure, and CI scaffolding are deferred to follow-up proposals or tasks
+AND this proposal remains focused on ownership boundaries.
+
+#### Scenario: Follow-up implementation proposals
+GIVEN the structure proposal is accepted
+WHEN work begins on frontend, backend, contracts, local infrastructure, or a future service extraction
+THEN each substantial implementation area references the accepted structure capability
+AND defines its own affected files, verification commands, and acceptance criteria.

--- a/openspec/changes/define-academy-monorepo-application-structure/tasks.md
+++ b/openspec/changes/define-academy-monorepo-application-structure/tasks.md
@@ -1,0 +1,23 @@
+## 1. Proposal Review
+
+- [ ] 1.1 Review the current root directory structure and confirm the intended ownership of `apps/`, `packages/`, `services/`, `infra/`, `docs/`, and `openspec/`.
+- [ ] 1.2 Review the per-directory README placeholders and identify any wording that conflicts with the accepted monorepo ownership model.
+- [ ] 1.3 Confirm `apps/gateway` and `services/*` remain deferred placeholders until future proposals activate them.
+
+## 2. Spec Application
+
+- [ ] 2.1 Add the accepted `academy-monorepo-structure` capability to baseline specs.
+- [ ] 2.2 Update repository README guidance if needed so the documented structure matches the accepted capability.
+- [ ] 2.3 Update app, package, service, or infra README placeholders if needed to align with the accepted maturity boundaries.
+
+## 3. Follow-Up Planning
+
+- [ ] 3.1 Create follow-up proposal candidates for frontend workspace scaffolding, Spring Boot API scaffolding, shared contracts setup, and local infrastructure setup.
+- [ ] 3.2 Identify which follow-up proposal should be implemented first based on dependency order.
+- [ ] 3.3 Confirm no application implementation code is included in this structure-definition change.
+
+## 4. Validation
+
+- [ ] 4.1 Run `openspec validate define-academy-monorepo-application-structure --strict`.
+- [ ] 4.2 Run `openspec validate --all --strict`.
+- [ ] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless README alignment edits are intentionally added during apply.


### PR DESCRIPTION
## Summary
- add OpenSpec proposal define-academy-monorepo-application-structure
- introduce academy-monorepo-structure capability delta
- define apps, packages, services, infra, docs, and openspec ownership boundaries
- make REST primary, WebSockets allowed, and GraphQL deferred
- keep apps/gateway and services/* as deferred placeholders until future proposals activate them

## Verification
- openspec validate define-academy-monorepo-application-structure --strict
- openspec validate --all --strict
- git diff --check

This is proposal-only; no implementation scaffolding is included.