### PR TITLE
docs: apply academy monorepo structure spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ packages/
   tsconfig/         Shared TypeScript configuration
 
 services/
-  code-runner/      Independent code execution service
-  notifications/    Independent notification delivery service
-  billing/          Independent billing integration service
+  code-runner/      Future independent code execution service
+  notifications/    Future independent notification delivery service
+  billing/          Future independent billing integration service
 
 infra/
   docker/           Docker assets
@@ -41,6 +41,10 @@ openspec/           OpenSpec capability specifications and active changes
 The current branch preserves the product documentation and specification work
 while removing implementation remnants from the previous frontend/backend stack.
 Application scaffolds will be added in focused follow-up changes.
+
+`apps/gateway` and `services/*` are reserved placeholders. They stay empty until
+a future OpenSpec proposal justifies activating those independently deployable
+boundaries.
 
 ## Planned Stack
 
@@ -109,3 +113,4 @@ Recommended branch flow:
 - [Design documentation](./docs/design/)
 - [OpenSpec specifications](./openspec/specs/)
 - [Feature analysis](./docs/feature-analysis.md)
+- [OpenSpec follow-up proposals](./docs/openspec-follow-up-proposals.md)

--- a/apps/README.md
+++ b/apps/README.md
@@ -6,4 +6,4 @@ Deployable applications live here.
 - `admin`: admin and instructor React application
 - `api`: primary Spring Boot API
 - `worker`: background worker application
-- `gateway`: optional API gateway
+- `gateway`: optional API gateway placeholder; keep empty until an accepted proposal defines routing, aggregation, or edge behavior

--- a/docs/openspec-follow-up-proposals.md
+++ b/docs/openspec-follow-up-proposals.md
@@ -1,0 +1,37 @@
+# OpenSpec Follow-Up Proposals
+
+This roadmap records the next proposal candidates after `academy-monorepo-structure`.
+
+## Recommended Order
+
+1. `scaffold-frontend-workspaces`
+   - Create `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config` implementation scaffolding.
+   - Establish strict TypeScript, Vite, Tailwind CSS, ShadCN, linting, formatting, and workspace scripts.
+   - Depends on `academy-monorepo-structure`.
+
+2. `scaffold-spring-boot-api`
+   - Create the primary `apps/api` Spring Boot application.
+   - Establish REST/WebSocket-ready backend structure, health checks, test setup, and local profile conventions.
+   - Depends on `academy-monorepo-structure`.
+
+3. `setup-shared-api-contracts`
+   - Create the initial `packages/contracts` structure for OpenAPI documents, shared schemas, and generated TypeScript clients.
+   - Define how frontend clients consume generated contracts.
+   - Depends on `scaffold-spring-boot-api` for initial API shape or may run in parallel if using contract-first stubs.
+
+4. `setup-local-development-infrastructure`
+   - Define Docker Compose services for PostgreSQL, Redis, S3-compatible storage, and local app wiring.
+   - Establish environment file conventions without committing secrets.
+   - Depends on the initial API and frontend scaffold decisions.
+
+5. Future service activation proposals
+   - `activate-code-runner-service`
+   - `activate-notifications-service`
+   - `activate-billing-service`
+   - Each service remains placeholder-only until its proposal defines deployment, data, contracts, observability, and failure behavior.
+
+## First Implementation Recommendation
+
+Start with `scaffold-frontend-workspaces`.
+
+Reason: the user-facing and admin React apps, shared UI package, TypeScript configuration, and linting conventions establish the highest-volume development surface. The backend and contracts proposals can then align around the frontend contract needs without prematurely extracting services.

--- a/openspec/changes/define-academy-monorepo-application-structure/tasks.md
+++ b/openspec/changes/define-academy-monorepo-application-structure/tasks.md
@@ -1,23 +1,23 @@
 ## 1. Proposal Review
 
-- [ ] 1.1 Review the current root directory structure and confirm the intended ownership of `apps/`, `packages/`, `services/`, `infra/`, `docs/`, and `openspec/`.
-- [ ] 1.2 Review the per-directory README placeholders and identify any wording that conflicts with the accepted monorepo ownership model.
-- [ ] 1.3 Confirm `apps/gateway` and `services/*` remain deferred placeholders until future proposals activate them.
+- [x] 1.1 Review the current root directory structure and confirm the intended ownership of `apps/`, `packages/`, `services/`, `infra/`, `docs/`, and `openspec/`.
+- [x] 1.2 Review the per-directory README placeholders and identify any wording that conflicts with the accepted monorepo ownership model.
+- [x] 1.3 Confirm `apps/gateway` and `services/*` remain deferred placeholders until future proposals activate them.
 
 ## 2. Spec Application
 
-- [ ] 2.1 Add the accepted `academy-monorepo-structure` capability to baseline specs.
-- [ ] 2.2 Update repository README guidance if needed so the documented structure matches the accepted capability.
-- [ ] 2.3 Update app, package, service, or infra README placeholders if needed to align with the accepted maturity boundaries.
+- [x] 2.1 Add the accepted `academy-monorepo-structure` capability to baseline specs.
+- [x] 2.2 Update repository README guidance if needed so the documented structure matches the accepted capability.
+- [x] 2.3 Update app, package, service, or infra README placeholders if needed to align with the accepted maturity boundaries.
 
 ## 3. Follow-Up Planning
 
-- [ ] 3.1 Create follow-up proposal candidates for frontend workspace scaffolding, Spring Boot API scaffolding, shared contracts setup, and local infrastructure setup.
-- [ ] 3.2 Identify which follow-up proposal should be implemented first based on dependency order.
-- [ ] 3.3 Confirm no application implementation code is included in this structure-definition change.
+- [x] 3.1 Create follow-up proposal candidates for frontend workspace scaffolding, Spring Boot API scaffolding, shared contracts setup, and local infrastructure setup.
+- [x] 3.2 Identify which follow-up proposal should be implemented first based on dependency order.
+- [x] 3.3 Confirm no application implementation code is included in this structure-definition change.
 
 ## 4. Validation
 
-- [ ] 4.1 Run `openspec validate define-academy-monorepo-application-structure --strict`.
-- [ ] 4.2 Run `openspec validate --all --strict`.
-- [ ] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless README alignment edits are intentionally added during apply.
+- [x] 4.1 Run `openspec validate define-academy-monorepo-application-structure --strict`.
+- [x] 4.2 Run `openspec validate --all --strict`.
+- [x] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless README alignment edits are intentionally added during apply.

--- a/openspec/specs/academy-monorepo-structure/spec.md
+++ b/openspec/specs/academy-monorepo-structure/spec.md
@@ -1,0 +1,142 @@
+# Academy Monorepo Structure Specification
+
+## Purpose
+
+Define the Presstronic Academy repository ownership model for applications, shared packages, future services, infrastructure, documentation, and OpenSpec artifacts.
+
+This specification captures durable workspace boundaries before implementation scaffolding begins. It does not specify individual API endpoints, database schemas, deployment environments, generated code layout, or service extraction timing.
+
+## Requirements
+
+### Requirement: Top-Level Workspace Ownership
+The repository SHALL use top-level directories with distinct ownership for deployable applications, shared packages, independently deployable services, infrastructure assets, documentation, and OpenSpec artifacts.
+
+#### Scenario: Repository ownership areas are present
+GIVEN the repository structure is prepared for implementation
+WHEN a contributor reviews the project root
+THEN `apps/` owns deployable application entry points
+AND `packages/` owns shared workspace packages
+AND `services/` owns future independently deployable backend services
+AND `infra/` owns infrastructure assets
+AND `docs/` owns product, architecture, and design documentation
+AND `openspec/` owns baseline specifications, active changes, and archived changes.
+
+#### Scenario: New top-level areas require justification
+GIVEN a future change proposes a new top-level directory
+WHEN the change is reviewed
+THEN the proposal identifies the ownership boundary that is not covered by the existing top-level areas
+AND avoids adding overlapping top-level directories for the same responsibility.
+
+### Requirement: Application Workspace Boundaries
+The repository SHALL treat `apps/web`, `apps/admin`, `apps/api`, `apps/worker`, and `apps/gateway` as deployable application workspaces with distinct maturity expectations.
+
+#### Scenario: Learner web application boundary
+GIVEN learner-facing frontend work is implemented
+WHEN the work belongs to the public or authenticated learner experience
+THEN it lives under `apps/web`
+AND uses React, strict TypeScript, Vite, Tailwind CSS, and ShadCN unless a later proposal changes the frontend stack.
+
+#### Scenario: Admin application boundary
+GIVEN admin or instructor frontend work is implemented
+WHEN the work belongs to operational, instructional, support, moderation, reporting, or administrative workflows
+THEN it lives under `apps/admin`
+AND uses React, strict TypeScript, Vite, Tailwind CSS, and ShadCN unless a later proposal changes the frontend stack.
+
+#### Scenario: Primary API application boundary
+GIVEN backend API work is implemented before a service-specific extraction is accepted
+WHEN the work exposes REST APIs, WebSocket workflows, authentication integration, or core Academy backend orchestration
+THEN it lives under `apps/api`
+AND uses Java Spring Boot as the primary backend application.
+
+#### Scenario: Worker application boundary
+GIVEN background work is implemented outside a request lifecycle
+WHEN the work performs async jobs, scheduled jobs, event processing, code-runner orchestration, email orchestration, or other background coordination
+THEN it lives under `apps/worker`
+AND does not create an independently deployable service boundary unless a later proposal justifies that split.
+
+#### Scenario: Gateway remains deferred
+GIVEN the repository contains `apps/gateway`
+WHEN no accepted proposal defines gateway routing, aggregation, edge authorization, or cross-service edge behavior
+THEN `apps/gateway` remains empty or placeholder-only
+AND application traffic continues to be owned by `apps/api` or infrastructure configuration.
+
+### Requirement: Shared Package Boundaries
+The repository SHALL use `packages/` for shared workspace packages that are consumed by applications without owning application workflows.
+
+#### Scenario: Shared UI package boundary
+GIVEN reusable frontend UI components are implemented for both learner and admin applications
+WHEN the components wrap or extend ShadCN primitives, shared Academy styling, accessibility behavior, or reusable component variants
+THEN they live under `packages/ui`
+AND app-specific screens, routes, data loading, and workflow state remain in `apps/web` or `apps/admin`.
+
+#### Scenario: Contracts package boundary
+GIVEN API contracts or generated frontend clients are introduced
+WHEN the contracts describe REST schemas, OpenAPI files, generated TypeScript clients, or shared validation schemas
+THEN they live under `packages/contracts`
+AND endpoint behavior remains owned by backend and product capability specs.
+
+#### Scenario: Shared frontend configuration boundary
+GIVEN frontend TypeScript or lint configuration is shared across workspaces
+WHEN the configuration is reusable across frontend applications or packages
+THEN TypeScript configuration lives under `packages/tsconfig`
+AND ESLint configuration lives under `packages/eslint-config`.
+
+### Requirement: Independently Deployable Service Maturity
+The repository SHALL reserve `services/` for backend capabilities that require independent deployment, scaling, isolation, data ownership, vendor integration, or operational ownership beyond the primary API.
+
+#### Scenario: Service placeholder is not an active boundary
+GIVEN a service directory exists under `services/`
+WHEN no accepted OpenSpec proposal activates that service
+THEN the directory remains placeholder-only
+AND production behavior is not implemented there.
+
+#### Scenario: Code-runner service activation
+GIVEN isolated code execution needs exceed what can safely be orchestrated from `apps/api` or `apps/worker`
+WHEN a later proposal activates `services/code-runner`
+THEN the proposal defines sandbox isolation, execution lifecycle, API contracts, observability, and failure behavior before implementation.
+
+#### Scenario: Notifications service activation
+GIVEN notification delivery needs independent scaling, delivery guarantees, provider integration, or operational ownership
+WHEN a later proposal activates `services/notifications`
+THEN the proposal defines message sources, delivery channels, retry behavior, observability, and ownership boundaries before implementation.
+
+#### Scenario: Billing service activation
+GIVEN billing integration needs independent deployment, provider isolation, compliance controls, or operational ownership outside `apps/api`
+WHEN a later proposal activates `services/billing`
+THEN the proposal defines billing contracts, entitlement synchronization, provider webhooks, observability, and failure behavior before implementation.
+
+### Requirement: API Style Defaults
+The repository SHALL use REST as the primary API style, allow WebSockets for live workflows, and defer GraphQL until a later proposal establishes a concrete need.
+
+#### Scenario: REST-first contract
+GIVEN frontend or external clients need backend data or commands
+WHEN API behavior is specified
+THEN REST endpoints and OpenAPI contracts are the default approach
+AND shared contract artifacts live under `packages/contracts`.
+
+#### Scenario: WebSocket workflow
+GIVEN a workflow needs live progress, streaming status, collaboration, notifications, or long-running job updates
+WHEN request-response REST polling is not sufficient
+THEN the proposal may specify WebSocket behavior
+AND defines connection lifecycle, authorization, events, retry behavior, and fallback behavior.
+
+#### Scenario: GraphQL remains deferred
+GIVEN a future change proposes GraphQL
+WHEN the proposal is reviewed
+THEN it identifies query composition, client data-shaping, or schema federation needs that REST and WebSockets do not satisfy
+AND defines how GraphQL coexists with existing REST contracts.
+
+### Requirement: Implementation Proposal Sequencing
+The repository SHALL separate structure approval from implementation scaffolding and SHALL require focused follow-up proposals for major implementation surfaces.
+
+#### Scenario: Structure proposal precedes scaffolding
+GIVEN this monorepo structure proposal is still active
+WHEN implementation work is planned
+THEN React, Spring Boot, contracts, service, infrastructure, and CI scaffolding are deferred to follow-up proposals or tasks
+AND this proposal remains focused on ownership boundaries.
+
+#### Scenario: Follow-up implementation proposals
+GIVEN the structure proposal is accepted
+WHEN work begins on frontend, backend, contracts, local infrastructure, or a future service extraction
+THEN each substantial implementation area references the accepted structure capability
+AND defines its own affected files, verification commands, and acceptance criteria.

--- a/services/README.md
+++ b/services/README.md
@@ -6,3 +6,7 @@ deployment, scaling, or operational boundaries.
 - `code-runner`: isolated code execution
 - `notifications`: notification delivery
 - `billing`: billing integration
+
+These directories are placeholders until accepted OpenSpec proposals activate
+them. Production behavior starts in `apps/api` or `apps/worker` unless a service
+proposal defines an independent deployment boundary.


### PR DESCRIPTION
## Summary
- add the accepted academy-monorepo-structure baseline spec
- mark define-academy-monorepo-application-structure tasks complete
- clarify README language around deferred gateway and services boundaries
- add an OpenSpec follow-up proposal roadmap

## Verification
- openspec validate define-academy-monorepo-application-structure --strict
- openspec validate --all --strict
- git diff --check

No application implementation scaffolding is included.