### PR TITLE
docs: propose academy mvp scope

### DIFF
--- a/docs/product/code-prompts-deliveries-and-learning-differentiators.md
+++ b/docs/product/code-prompts-deliveries-and-learning-differentiators.md
@@ -1,0 +1,479 @@
+# Code Prompts, Deliveries, and Learning Differentiators
+
+This document captures product ideas for making Presstronic Academy more than a tutorial platform. These ideas are intentionally broader than MVP scope. They should be refined into OpenSpec proposals only after the product direction is reviewed.
+
+## Product Thesis
+
+Presstronic Academy should teach learners to ship coherent engineering work, not just solve isolated exercises.
+
+The core learning loop should be:
+
+1. Enter a mission.
+2. Make technical decisions under constraints.
+3. Build, debug, refactor, or review a realistic system.
+4. Submit a delivery.
+5. Receive tests, rubric feedback, review guidance, and consequences.
+6. Revise and improve.
+7. Add the result to a durable skill record, portfolio artifact, or hiring evidence packet.
+
+The platform should preserve the CYOA theme wherever it helps learning. Every meaningful activity should feel like a mission with context, stakes, and consequences, without burying the learning under lore.
+
+## Core Concept: Code Prompts
+
+A Code Prompt is a scenario-based project assignment. It may start from a blank repository, a partial project, a broken system, or a production-like codebase. The learner or candidate must take the project to an acceptable delivery.
+
+Unlike a normal coding challenge, a Code Prompt asks:
+
+> Can you ship a coherent piece of engineering work?
+
+### Prompt Types
+
+- **Greenfield Prompt**: Start from little or no project structure and build toward a goal.
+- **Feature Prompt**: Add a feature to an existing application.
+- **Bugfix Prompt**: Diagnose and fix a failing or flaky system.
+- **Refactor Prompt**: Improve design while preserving behavior.
+- **Integration Prompt**: Wire frontend, backend, API contracts, and persistence.
+- **Incident Prompt**: Investigate logs, failing tests, or symptoms and ship a fix.
+- **Architecture Prompt**: Propose and implement a bounded design.
+- **Interview Prompt**: Complete a timed take-home style assignment.
+- **Portfolio Prompt**: Produce polished work suitable for sharing as evidence.
+
+### Prompt Anatomy
+
+A strong Code Prompt can include:
+
+- Mission brief
+- Scenario and stakeholder context
+- Objective
+- Constraints
+- Starter repository or blank workspace
+- Visible tests
+- Hidden tests
+- Expected behaviors
+- Allowed tools
+- Delivery checklist
+- Rubric
+- Time guidance or time box
+- Review criteria
+- Follow-up missions
+
+## Core Concept: Submit a Delivery
+
+A Delivery is the submitted artifact for a Code Prompt. The term matters because it frames the work as engineering output, not just an answer.
+
+A Delivery may include:
+
+- Code changes
+- Passing tests
+- New tests
+- README or implementation notes
+- Assumptions
+- Tradeoffs
+- API contract changes
+- Migration notes
+- Screenshots or demo evidence
+- ADR or short design note
+- Known limitations
+- Follow-up recommendations
+
+### Delivery Evaluation Dimensions
+
+Deliveries can be evaluated across:
+
+- **Correctness**: Does it work?
+- **Completeness**: Did it meet the prompt?
+- **Testing**: Did the learner add meaningful tests?
+- **Maintainability**: Is the implementation understandable and changeable?
+- **Design Judgment**: Did the learner choose a reasonable approach?
+- **Communication**: Did they explain assumptions and tradeoffs?
+- **Production Readiness**: Would this survive review?
+- **Operational Risk**: What could fail after release?
+- **Security and Privacy**: Did the solution avoid unsafe behavior?
+- **Accessibility**: For UI work, did the delivery preserve accessible behavior?
+
+### Evaluation Maturity
+
+1. **Tests Only**
+   - Visible tests
+   - Hidden tests
+   - Lint/typecheck/build
+   - Basic pass/fail
+
+2. **Static Quality Checks**
+   - Formatting
+   - Complexity
+   - Dependency rules
+   - Security checks
+   - Architecture boundary checks
+
+3. **Rubric Review**
+   - Correctness
+   - Maintainability
+   - Test quality
+   - API design
+   - Data modeling
+   - Error handling
+   - Accessibility
+   - Performance
+
+4. **AI-Assisted Review**
+   - Explain tradeoffs
+   - Spot missing edge cases
+   - Compare against rubric
+   - Recommend next learning
+   - Generate follow-up drills from weaknesses
+
+5. **Human or Instructor Review**
+   - Useful for advanced paths, cohorts, paid tiers, certificates, and hiring assessments.
+
+## CYOA and Mission Framing
+
+Code Prompts should feel like missions.
+
+Example:
+
+```text
+Mission Brief
+A customer success team reports that paid learners are losing access after renewal.
+Billing events are arriving, but entitlements are not updating consistently.
+
+Objective
+Ship a delivery that restores entitlement sync and proves the failure cannot recur.
+
+Constraints
+- Do not change the public API contract.
+- Preserve existing subscription states.
+- Add regression coverage.
+- Document any assumptions.
+
+Delivery Required
+- Code changes
+- Tests
+- Implementation note
+- Risk assessment
+```
+
+After submission:
+
+```text
+Review Outcome
+Delivery accepted with caution.
+
+Strengths
+- Correctly handled duplicate webhook events.
+- Added regression coverage for renewal events.
+
+Risk
+- Retry behavior is not observable enough for production.
+
+Unlocked Follow-Up
+Add event tracing to the billing pipeline.
+```
+
+CYOA can show up through:
+
+- Narrative mission briefs
+- Decision points before implementation
+- Consequences in the review report
+- Branch unlocks based on delivery quality
+- Persistent learner identity as an operator
+- Mission log entries for every delivery
+- Follow-up missions triggered by mistakes, risks, or strengths
+
+The story should sharpen the stakes and make choices memorable. It should not obscure the technical learning objective.
+
+## B2B Hiring Assessments
+
+Code Prompts can become a B2B assessment product for companies that want realistic candidate evaluation.
+
+The value proposition:
+
+> Evaluate how candidates deliver real engineering work, not just whether they can solve isolated algorithm problems.
+
+### Company Use Cases
+
+- Assign realistic take-home missions.
+- Standardize evaluation across candidates.
+- Use hidden tests and rubric scoring.
+- Review code quality, design judgment, and communication.
+- Compare candidates with evidence packets.
+- Generate live interview follow-up questions.
+- Maintain private prompt libraries.
+- Customize prompts to match real company work.
+
+### Candidate Assessment Delivery
+
+Candidates submit a Delivery that may include:
+
+- Code
+- Tests
+- Implementation notes
+- Tradeoff explanation
+- Assumptions
+- Screenshots or demo evidence
+- ADR
+- Known limitations
+
+### Company Review Packet
+
+Hiring teams receive a Review Packet:
+
+- Test results
+- Rubric scores
+- Strengths
+- Risks
+- Design assessment
+- Maintainability assessment
+- Communication assessment
+- Security and performance flags
+- Suggested live interview follow-up questions
+- Evidence for hiring panel discussion
+
+The product should avoid claiming that AI decides who to hire. The safer and more credible positioning:
+
+> Presstronic generates structured evidence and review guidance for human hiring teams.
+
+### Role-Based Assessment Tracks
+
+- **Frontend Engineer**
+  - Fix a broken checkout flow.
+  - Build an accessible data table.
+  - Integrate with an API contract.
+  - Improve loading and error states.
+
+- **Backend Engineer**
+  - Implement an idempotent webhook handler.
+  - Design a REST endpoint with validation.
+  - Fix a transaction boundary bug.
+  - Add background job retry behavior.
+
+- **Full Stack Engineer**
+  - Implement a feature across React and Spring Boot.
+  - Update an OpenAPI contract and generated client.
+  - Handle optimistic UI and backend validation.
+
+- **Platform Engineer**
+  - Containerize a service.
+  - Add health checks.
+  - Diagnose a failing deployment.
+  - Improve observability.
+
+- **Staff or Lead Engineer**
+  - Evaluate an architecture proposal.
+  - Write an ADR.
+  - Identify a migration plan.
+  - Reduce risk in a partially implemented system.
+
+### B2B-Specific Capabilities
+
+Future company-facing features may include:
+
+- Company tenant accounts
+- Prompt assignment links
+- Candidate identity/session handling
+- Time-boxed assessments
+- Anti-cheating controls
+- Plagiarism or similarity checks
+- Private prompt libraries
+- Custom company prompts
+- Hiring team dashboard
+- Evaluation rubric editor
+- Candidate review packets
+- Interview follow-up question generator
+- Legal/privacy controls
+- Data retention settings
+
+## Learning Differentiators
+
+These features are broader than Code Prompts but fit the same thesis: help people learn real engineering judgment.
+
+### Adaptive Review Queue
+
+Use spaced repetition and retrieval practice for programming concepts, debugging patterns, API design decisions, command-line fluency, SQL mistakes, and architecture tradeoffs.
+
+Examples:
+
+- "You failed async error handling twice last week."
+- "Here is a short bug diagnosis drill."
+- "Pick the safest migration plan."
+- "Explain what this stack trace means."
+
+This should not be limited to flashcards. It should generate active recall work from the learner's history.
+
+### Mistake Memory and Error Pattern Tracker
+
+Track recurring mistakes and turn them into targeted practice.
+
+Examples:
+
+- Off-by-one errors
+- Missing null handling
+- Async race conditions
+- Over-broad exception handling
+- SQL joins that duplicate rows
+- Incorrect React derived state
+- Spring transaction boundary mistakes
+
+Learners should see:
+
+> These are the bugs I tend to create.
+
+The system should use these patterns to assign review drills, follow-up prompts, and mentor guidance.
+
+### Debugging-First Challenges
+
+Most platforms overemphasize greenfield code. Real engineers spend much of their time reading, tracing, debugging, and modifying existing systems.
+
+Challenge types:
+
+- Find the bug.
+- Explain why this test fails.
+- Trace this request across frontend, API, and database.
+- Patch without changing public behavior.
+- Refactor safely.
+- Choose which log line matters.
+
+### Decision Missions
+
+Decision Missions teach tradeoffs.
+
+Example:
+
+- The queue is backing up.
+- The learner can scale workers, add backpressure, add a dead-letter queue, change retry policy, or inspect poison messages.
+- Each choice changes cost, reliability, complexity, and future incidents.
+
+These missions can be CYOA-native and may not require much coding at first. They train engineering judgment.
+
+### Skill Graph
+
+Track learner mastery as a graph, not only course completion.
+
+Possible skill nodes:
+
+- HTTP basics
+- Auth/session handling
+- SQL joins
+- Transactions
+- Async jobs
+- Testing
+- Observability
+- Threat modeling
+- Refactoring
+- Accessibility
+- API contracts
+- State management
+
+Lessons, missions, challenges, and deliveries update the graph.
+
+The learner should see:
+
+- Strong areas
+- Weak areas
+- Concepts due for review
+- Skills demonstrated by portfolio artifacts
+- Skills demonstrated by hiring assessments
+
+### Pre-Mortem and Postmortem Training
+
+Teach incident thinking.
+
+Feature ideas:
+
+- Before deploying a solution, learner identifies likely failure modes.
+- After a simulated incident, learner writes a postmortem.
+- The system evaluates root cause, blast radius, detection gaps, prevention, and communication quality.
+
+### Parsons Problems
+
+Parsons problems give learners scrambled code blocks they must arrange correctly. They reduce syntax burden while testing structure and understanding.
+
+Useful contexts:
+
+- Beginner programming
+- Mobile coding
+- Syntax-heavy concepts
+- Refactoring order
+- Pipeline composition
+- SQL query construction
+
+### AI Mentor With Guardrails
+
+The AI mentor should teach through constraints, not solve for the learner.
+
+Rules:
+
+- No direct answers.
+- Scope to current lesson or prompt.
+- Use a hint ladder.
+- Ask the learner to predict before revealing.
+- Point to relevant prior mistakes.
+- Generate similar-but-not-identical practice.
+- Explain errors rather than write final code.
+- Say when the learner is asking to skip the learning.
+
+### Code Review Simulator
+
+Learners should practice receiving and giving reviews.
+
+Review dimensions:
+
+- Correctness
+- Readability
+- Test coverage
+- Edge cases
+- Security
+- Performance
+- Maintainability
+- API design
+- Accessibility for UI work
+
+The system can review a learner's delivery, then later ask the learner to review another implementation.
+
+### Portfolio-Grade Artifacts
+
+Each path should produce artifacts that learners can keep.
+
+Artifacts may include:
+
+- GitHub repository
+- Architecture decision record
+- Test suite
+- Incident report
+- API contract
+- Deployment notes
+- Screenshots
+- Verification report
+- Certificate with skill evidence
+
+The goal is not only "I finished a course." The goal is:
+
+> Here is evidence of what I can ship.
+
+## Possible Future OpenSpec Capabilities
+
+These ideas should likely become separate OpenSpec proposals:
+
+- `define-academy-code-prompts`
+- `define-academy-deliveries`
+- `define-academy-delivery-review`
+- `define-academy-hiring-assessments`
+- `define-academy-prompt-authoring`
+- `define-academy-adaptive-review`
+- `define-academy-mistake-memory`
+- `define-academy-debugging-challenges`
+- `define-academy-decision-missions`
+- `define-academy-skill-graph`
+- `define-academy-portfolio-artifacts`
+
+## Open Questions
+
+- Should Code Prompts be a content type inside courses, or a separate top-level product area?
+- Should Deliveries be available to individual learners before hiring assessments exist?
+- Should B2B hiring assessments share the same prompt engine as learner prompts from day one?
+- What parts of a Delivery are required versus optional?
+- How much should AI review be trusted before human review is available?
+- Should companies be allowed to write custom prompts, or should Presstronic control prompt quality?
+- How should the product prevent copying, prompt leakage, and over-reliance on AI tools?
+- Should CYOA consequences affect only narrative unlocks, or also the learner's skill graph?
+- What is the right balance between serious engineering review and the Academy mission aesthetic?

--- a/openspec/changes/define-academy-mvp-scope/.openspec.yaml
+++ b/openspec/changes/define-academy-mvp-scope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/define-academy-mvp-scope/README.md
+++ b/openspec/changes/define-academy-mvp-scope/README.md
@@ -1,0 +1,3 @@
+# define-academy-mvp-scope
+
+Define Presstronic Academy MVP scope, limited differentiators, and explicitly deferred capabilities before implementation scaffolding.

--- a/openspec/changes/define-academy-mvp-scope/design.md
+++ b/openspec/changes/define-academy-mvp-scope/design.md
@@ -1,0 +1,75 @@
+## Context
+
+The Academy baseline currently includes specs for learner-facing product surfaces, visual design, auth, billing/access, progression, certificates, story, lesson challenge, privacy, and monorepo structure. A product concept brief now captures broader ideas around Code Prompts, Deliveries, B2B hiring assessments, adaptive review, mistake memory, debugging-first challenges, decision missions, skill graphs, postmortem training, AI guardrails, code review simulation, and portfolio artifacts.
+
+The risk is trying to implement the entire vision before proving the core learning loop. The MVP should still feel differentiated, but it should not require every future system.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the first shippable product loop.
+- Preserve CYOA theming and mission framing without requiring a full branching engine.
+- Include a small but real version of Code Prompts and Deliveries because they are central differentiators.
+- Make admin/content operations and content health visible enough to run and improve the product.
+- Explicitly defer B2B hiring assessments and advanced learning intelligence until after the learner product proves the loop.
+
+**Non-Goals:**
+
+- Do not scaffold frontend, backend, code runner, admin, or database implementation.
+- Do not fully specify Code Prompts, Delivery review, admin CMS, or content health dashboards in this change.
+- Do not activate multi-tenancy, hiring assessments, public profiles, certificates, enterprise integrations, or microservices.
+- Do not decide pricing or launch gating beyond identifying it as invite-gate or billing-gate scope.
+
+## Decisions
+
+### Decision: MVP proves one complete learning loop
+
+The MVP should prove one complete path from mission-framed content through a realistic submitted Delivery. This prevents the product from becoming a disconnected set of screens.
+
+Alternative considered: scaffold all planned surfaces first. That would create breadth but delay proof that the learning model works.
+
+### Decision: Include Code Prompts and Deliveries in limited form
+
+Code Prompts and "Submit a Delivery" are core differentiators. The MVP should include a basic version with starter projects, visible/hidden tests where feasible, delivery checklist, implementation notes, attempt history, and a basic review report.
+
+Alternative considered: defer Code Prompts entirely. That would make MVP closer to a conventional lesson/challenge platform and weaken the differentiator.
+
+### Decision: Keep CYOA as framing before full branching
+
+The MVP should use mission briefs, operation language, limited decision prompts, review consequences, and unlock-style feedback. Full branching story graph, rewind complexity, and path divergence can wait.
+
+Alternative considered: build full CYOA first. That would increase content, state, and authoring complexity before the core runner/delivery loop is proven.
+
+### Decision: Admin content and content health are MVP infrastructure
+
+Admin content management and basic content health are not polish. They are needed to create, publish, observe, and improve the first shippable course.
+
+Alternative considered: hand-author all content in code or database seed files. That may be useful for prototypes, but it does not support iteration once learners use the product.
+
+### Decision: B2B hiring assessments are future product direction
+
+Hiring assessments share the Code Prompt and Delivery engine, but company tenants, candidate packets, rubric editors, anti-cheating, and custom prompt libraries are deferred until the learner workflow is proven.
+
+Alternative considered: launch B2B immediately. That adds legal, privacy, sales, integrity, and tenant complexity before the core assessment engine exists.
+
+## Risks / Trade-offs
+
+- Limited Code Prompts may feel less powerful than the vision -> Keep scope honest but make the delivery loop real.
+- Deferring full CYOA may dilute differentiation -> Preserve mission framing and consequences from day one.
+- Admin/content work can expand quickly -> Limit MVP to content creation, preview, publish, and essential health signals.
+- AI mentor expectations can grow quickly -> Ship guardrails and authored hints first if live AI slows launch.
+
+## Migration Plan
+
+1. Accept this MVP scope proposal.
+2. Apply it into a baseline `academy-mvp-scope` spec.
+3. Create focused follow-up proposals for Code Prompts/Deliveries, admin content management, content health dashboard, AI mentor guardrails, and implementation scaffolding.
+4. Use this scope spec to reject or defer implementation work that does not support the first learning loop.
+
+## Open Questions
+
+- Should MVP launch with invite gating, paid billing, or both?
+- Should AI mentor be live-model backed in MVP, or should MVP start with authored hint ladders and guardrails?
+- Should Code Prompts be integrated into the first course path or exposed as a separate prompt catalog from day one?
+- How many Code Prompts are enough to prove the delivery loop?

--- a/openspec/changes/define-academy-mvp-scope/proposal.md
+++ b/openspec/changes/define-academy-mvp-scope/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The current OpenSpec baseline captures a broad product vision, and the product discovery notes add more differentiators such as Code Prompts, Deliveries, mistake memory, adaptive review, and hiring assessments. Before implementation scaffolding begins, the project needs an explicit MVP scope contract that defines the first shippable learning loop and separates MVP, MVP-lite, post-MVP, and future/B2B capabilities.
+
+## What Changes
+
+- Add a new `academy-mvp-scope` capability that defines the first shippable product outcome.
+- Define the MVP learning loop: mission-framed course -> lesson -> focused coding challenge -> Code Prompt -> submit a Delivery -> tests and basic review -> revision -> accepted Delivery appears in learner evidence/progress.
+- Classify existing baseline capabilities that remain in MVP scope, including auth, catalog, dashboard, lesson challenge, profile, progression, mission log, design system, privacy controls, and monorepo structure.
+- Add limited MVP scope for Code Prompts, Deliveries, basic review reports, attempt history, admin content management, and content health dashboard.
+- Define MVP-lite treatment for CYOA theming, AI mentor guardrails, and launch gating.
+- Explicitly defer full branching story engine, hiring assessments, advanced AI review, adaptive learning intelligence, public profiles, certificates, portfolio export, multi-tenancy, enterprise integrations, and microservice activation.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-mvp-scope`: First shippable product scope, MVP learning loop, included capabilities, limited differentiators, and deferred capabilities.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affects planning and sequencing for future OpenSpec proposals.
+- Provides scope constraints for frontend, backend, contracts, content, code runner, and admin scaffolding.
+- Does not implement application code, database schemas, API endpoints, or UI screens.
+- Future proposals for Code Prompts, admin content management, AI mentor guardrails, and content health should reference this MVP scope.

--- a/openspec/changes/define-academy-mvp-scope/specs/academy-mvp-scope/spec.md
+++ b/openspec/changes/define-academy-mvp-scope/specs/academy-mvp-scope/spec.md
@@ -1,0 +1,151 @@
+## ADDED Requirements
+
+### Requirement: MVP Learning Outcome
+The MVP SHALL prove that Presstronic Academy can teach real engineering through mission-framed learning, code execution, feedback, and evidence of delivery.
+
+#### Scenario: MVP outcome is reviewed
+GIVEN MVP scope is evaluated
+WHEN a capability or task is proposed for the first release
+THEN it supports the mission-framed learning loop, code challenge loop, delivery loop, learner progress evidence, or content operations needed to run the product
+AND work outside those outcomes is deferred unless explicitly accepted by a later proposal.
+
+#### Scenario: MVP is not a full product vision
+GIVEN a feature appears in product discovery notes or future concept documents
+WHEN it is not required to prove the first shippable learning loop
+THEN it is classified as MVP-lite, post-MVP, future/B2B, or explicitly deferred
+AND does not block implementation scaffolding.
+
+### Requirement: First Shippable Learning Loop
+The MVP SHALL include one complete learner loop from mission-framed course entry through accepted Delivery evidence.
+
+#### Scenario: Learner completes MVP loop
+GIVEN a learner enters the first shippable path
+WHEN the learner progresses through the path
+THEN the system presents mission-framed course context
+AND presents lesson content
+AND presents a focused coding challenge
+AND presents a Code Prompt
+AND accepts a Delivery
+AND runs tests or evaluation checks
+AND presents a basic review report
+AND allows revision when the Delivery is not accepted
+AND records the accepted Delivery in learner progress or evidence.
+
+#### Scenario: MVP loop remains coherent
+GIVEN a feature is added to MVP
+WHEN the feature does not support the first shippable learning loop
+THEN the feature is deferred or moved to a future proposal
+AND the MVP remains focused on shipping one coherent learner path.
+
+### Requirement: MVP Core Capability Scope
+The MVP SHALL include the learner, content, challenge, delivery, progress, and operational capabilities required to run the first shippable product.
+
+#### Scenario: Existing learner capabilities remain in MVP
+GIVEN implementation planning begins
+WHEN existing baseline capabilities are mapped to MVP
+THEN landing, auth entry, privacy controls, shell, catalog, dashboard, lesson challenge, mission log, profile, progression, design system components, visual design, and monorepo structure remain in MVP scope as needed by the first learning loop.
+
+#### Scenario: New MVP capabilities are identified
+GIVEN implementation planning begins
+WHEN gaps are mapped to MVP
+THEN admin content management, Code Prompts, Deliveries, attempt history, basic review reports, and content health dashboard are treated as MVP-critical or MVP-limited capability areas
+AND receive focused follow-up proposals before implementation.
+
+#### Scenario: Billing and launch gating remain limited
+GIVEN the MVP requires controlled access
+WHEN launch gating is specified
+THEN the product uses either invite gating, basic billing/access gating, or both
+AND does not require full subscription lifecycle sophistication before the learner loop is proven.
+
+### Requirement: Code Prompts and Deliveries MVP Scope
+The MVP SHALL include a limited Code Prompt and Delivery workflow that proves realistic engineering work can be submitted and reviewed.
+
+#### Scenario: MVP Code Prompt
+GIVEN a learner reaches an MVP Code Prompt
+WHEN the prompt is displayed
+THEN the system provides a mission brief, objective, constraints, starter project or workspace instructions, delivery checklist, and evaluation expectations.
+
+#### Scenario: MVP Delivery
+GIVEN a learner completes work for a Code Prompt
+WHEN the learner submits a Delivery
+THEN the Delivery includes code or project changes
+AND may include implementation notes, assumptions, tradeoffs, tests, screenshots, or other evidence required by the prompt
+AND is associated with the learner, prompt, attempt, and evaluation result.
+
+#### Scenario: MVP review report
+GIVEN a Delivery is evaluated
+WHEN evaluation completes
+THEN the system presents test results or evaluation checks
+AND presents a basic review report with accepted, needs revision, or failed status
+AND records feedback that can guide the next revision.
+
+### Requirement: MVP-Lite Differentiators
+The MVP SHALL include limited differentiators that preserve the Academy identity without requiring advanced systems.
+
+#### Scenario: CYOA theming without full branching
+GIVEN MVP lessons, challenges, or Code Prompts are presented
+WHEN the learner interacts with the content
+THEN the system uses mission briefs, operation language, decision framing, and consequence-aware feedback
+AND does not require a full branching story engine before release.
+
+#### Scenario: AI mentor guardrails before advanced AI
+GIVEN help or mentor behavior is included in MVP
+WHEN the learner requests assistance
+THEN the system follows no-direct-answer, hint-ladder, lesson-scope, and explain-don't-solve guardrails
+AND may use authored hints before live AI review is implemented.
+
+#### Scenario: Skill evidence before advanced skill graph
+GIVEN learner progress is displayed in MVP
+WHEN lessons, challenges, or Deliveries are completed
+THEN the system records completed work, challenge outcomes, accepted Deliveries, and basic skill tags
+AND does not require a full adaptive skill graph before release.
+
+### Requirement: Deferred Post-MVP Capabilities
+The MVP SHALL explicitly defer advanced learner features that are valuable but not required for the first shippable loop.
+
+#### Scenario: Advanced learning intelligence is deferred
+GIVEN adaptive review, mistake memory, debugging-first challenge libraries, decision mission libraries, pre-mortem training, postmortem training, Parsons problems, code review simulation, or advanced skill graphs are proposed
+WHEN they are not needed for the first shippable loop
+THEN they are captured as post-MVP capabilities
+AND require separate OpenSpec proposals before implementation.
+
+#### Scenario: Public evidence features are deferred
+GIVEN public profiles, certificates, portfolio export, GitHub publishing, or public artifact sharing are proposed
+WHEN MVP scope is enforced
+THEN they are deferred unless a later proposal makes them necessary for launch.
+
+#### Scenario: Full CYOA is deferred
+GIVEN full story branching, path divergence, complex rewind, or authored branch graph tooling is proposed
+WHEN MVP scope is enforced
+THEN those features are deferred
+AND MVP keeps mission framing and limited decisions.
+
+### Requirement: Future B2B Assessment Scope
+The MVP SHALL treat hiring assessments as future product direction that shares the Code Prompt and Delivery foundation but does not ship in the first learner MVP.
+
+#### Scenario: Hiring assessment is proposed
+GIVEN company assessments, candidate deliveries, review packets, rubric editors, custom company prompts, anti-cheating, plagiarism checks, or tenant-specific prompt libraries are proposed
+WHEN MVP scope is enforced
+THEN those features are classified as future/B2B
+AND require separate proposals after the learner delivery loop is proven.
+
+#### Scenario: Shared foundation is preserved
+GIVEN Code Prompt or Delivery behavior is designed for MVP
+WHEN future B2B assessment needs are considered
+THEN the design avoids choices that prevent later company assignments, candidate review packets, or rubric-based assessment
+AND does not implement B2B workflow before it is accepted.
+
+### Requirement: MVP Proposal Sequencing
+The MVP SHALL be implemented through focused proposals that reference the accepted MVP scope.
+
+#### Scenario: Focused proposals follow MVP scope
+GIVEN MVP scope is accepted
+WHEN implementation planning continues
+THEN focused proposals define frontend scaffolding, Spring Boot API scaffolding, shared contracts, local infrastructure, admin content management, Code Prompts and Deliveries, content health dashboard, and AI mentor guardrails
+AND each proposal identifies whether it supports MVP, MVP-lite, post-MVP, or future/B2B scope.
+
+#### Scenario: Scope disputes are resolved by MVP loop
+GIVEN contributors disagree about whether a feature belongs in MVP
+WHEN the feature is reviewed
+THEN the decision is made by whether the feature is required to prove the first shippable learning loop
+AND the feature is deferred when it adds breadth without strengthening that loop.

--- a/openspec/changes/define-academy-mvp-scope/tasks.md
+++ b/openspec/changes/define-academy-mvp-scope/tasks.md
@@ -1,0 +1,23 @@
+## 1. Scope Review
+
+- [ ] 1.1 Review existing baseline specs and identify capabilities already covered by MVP.
+- [ ] 1.2 Review `docs/product/code-prompts-deliveries-and-learning-differentiators.md` and classify ideas as MVP, MVP-lite, post-MVP, future/B2B, or deferred.
+- [ ] 1.3 Confirm the first shippable learner loop and the minimum capabilities required to prove it.
+
+## 2. MVP Scope Application
+
+- [ ] 2.1 Add the accepted `academy-mvp-scope` capability to baseline specs.
+- [ ] 2.2 Update product or planning documentation if needed so MVP scope and future ideas remain aligned.
+- [ ] 2.3 Confirm Code Prompts and Deliveries remain MVP-limited while hiring assessments remain future/B2B.
+
+## 3. Follow-Up Proposal Planning
+
+- [ ] 3.1 Create or update follow-up proposal candidates for Code Prompts and Deliveries, admin content management, content health dashboard, AI mentor guardrails, frontend scaffolding, backend scaffolding, contracts, and infrastructure.
+- [ ] 3.2 Identify which focused proposal should come first after MVP scope is accepted.
+- [ ] 3.3 Confirm no application implementation code is included in this scope-definition change.
+
+## 4. Validation
+
+- [ ] 4.1 Run `openspec validate define-academy-mvp-scope --strict`.
+- [ ] 4.2 Run `openspec validate --all --strict`.
+- [ ] 4.3 Confirm the proposal branch contains only product documentation and OpenSpec planning artifacts.


### PR DESCRIPTION
## Summary
- add broad product concept brief for Code Prompts, Deliveries, hiring assessments, and learning differentiators
- add OpenSpec proposal define-academy-mvp-scope
- introduce academy-mvp-scope capability delta
- classify core MVP, MVP-lite, post-MVP, and future/B2B scope
- define the first shippable learner loop around mission-framed learning, challenges, Code Prompts, Deliveries, review, revision, and learner evidence

## Verification
- openspec validate define-academy-mvp-scope --strict
- openspec validate --all --strict
- git diff --check

This is planning/documentation only; no implementation scaffolding is included.