### PR TITLE
docs: propose academy code prompts and deliveries

### DIFF
--- a/openspec/changes/define-academy-code-prompts-and-deliveries/.openspec.yaml
+++ b/openspec/changes/define-academy-code-prompts-and-deliveries/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/define-academy-code-prompts-and-deliveries/README.md
+++ b/openspec/changes/define-academy-code-prompts-and-deliveries/README.md
@@ -1,0 +1,3 @@
+# define-academy-code-prompts-and-deliveries
+
+Define Code Prompts, workspaces, Deliveries, attempts, evaluation checks, review reports, revisions, learner evidence, and future hiring-assessment boundaries.

--- a/openspec/changes/define-academy-code-prompts-and-deliveries/design.md
+++ b/openspec/changes/define-academy-code-prompts-and-deliveries/design.md
@@ -1,0 +1,72 @@
+## Context
+
+Presstronic Academy's MVP scope is built around a complete learning loop:
+
+mission-framed course -> lesson -> focused coding challenge -> Code Prompt -> submit a Delivery -> tests and basic review -> revision -> accepted Delivery appears in learner evidence/progress.
+
+The existing lesson challenge spec covers focused coding challenges. Code Prompts are different: they are project-style missions where the learner must deliver a coherent piece of engineering work. They may include code, tests, notes, assumptions, tradeoffs, screenshots, API changes, or other evidence required by the prompt.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define Code Prompts and Deliveries as first-class learner capabilities.
+- Keep MVP evaluation realistic but limited: checks, tests, review status, revision guidance, and basic evidence.
+- Connect accepted Deliveries to progression and mission-log behavior.
+- Preserve the CYOA/mission framing in prompt language, decisions, consequences, and review outcomes.
+- Preserve a foundation for future B2B hiring assessments without implementing B2B workflows now.
+
+**Non-Goals:**
+
+- Do not define final data schemas, API endpoints, runner implementation, or workspace execution environment.
+- Do not define admin prompt-authoring workflows in detail; that belongs to `define-academy-admin-content-management`.
+- Do not define content health dashboards in detail; that belongs to `define-academy-content-health-dashboard`.
+- Do not define future company assessments, custom company prompt libraries, anti-cheating, plagiarism detection, candidate packets, or rubric editor tooling.
+- Do not replace focused lesson challenges; Code Prompts complement them.
+
+## Decisions
+
+### Decision: Treat Delivery as the submitted artifact
+
+The platform should use "Delivery" as the learner-facing term for submitted engineering work. A Delivery may include code, tests, notes, assumptions, tradeoffs, screenshots, or other required evidence.
+
+Alternative considered: use "submission" everywhere. That is generic and loses the product framing: learners are practicing how to ship a delivery.
+
+### Decision: Keep MVP review report bounded
+
+MVP review reports should include evaluation results, status, strengths or passed checks, risks or failed checks, and revision guidance. Full AI design review, hiring panel evidence packets, and advanced rubric editors are deferred.
+
+Alternative considered: launch with AI review as the main evaluator. That would make the MVP dependent on review quality and policy decisions before the simpler test/check loop is proven.
+
+### Decision: Separate focused challenges from Code Prompts
+
+Focused challenges remain local to lesson skills and code execution. Code Prompts are broader, project-style missions with delivery evidence and revisions.
+
+Alternative considered: fold Code Prompts into lesson challenges. That would blur the boundary and make lesson challenge behavior too broad.
+
+### Decision: Preserve B2B compatibility but defer B2B workflows
+
+The same prompt/delivery foundation can later support hiring assessments. MVP should avoid design choices that block candidate review packets or company assignments, but it should not implement company tenants or hiring workflows.
+
+Alternative considered: define hiring assessments now. That would add tenant, legal, privacy, anti-cheating, and rubric management concerns before the learner prompt loop exists.
+
+## Risks / Trade-offs
+
+- Code Prompts can become too broad -> Keep MVP prompt anatomy and review report bounded.
+- Evaluation may overfit to tests -> Add implementation notes, assumptions, and risk feedback from the start, even if advanced AI review is deferred.
+- Workspace scope can expand into a full cloud IDE -> Specify lifecycle requirements now and defer execution environment choices to implementation proposals.
+- B2B needs may influence learner UX too early -> Keep future assessment compatibility as a boundary, not an MVP workflow.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Apply the `academy-code-prompts-deliveries` baseline capability and modified boundaries.
+3. Create follow-up implementation proposals for admin prompt authoring, frontend prompt/workspace UX, API/contracts, runner/evaluation integration, and content health visibility.
+4. Defer hiring-assessment proposals until learner Code Prompts and Deliveries are proven.
+
+## Open Questions
+
+- Should MVP Code Prompt workspaces be browser-only, repo-backed, container-backed, or implementation-defined until runner proposals land?
+- What evidence fields are required for the first Code Prompt versus optional?
+- Should a revision create a new Delivery record, a new attempt under the same Delivery, or both?
+- How many accepted Deliveries should the first path require?

--- a/openspec/changes/define-academy-code-prompts-and-deliveries/proposal.md
+++ b/openspec/changes/define-academy-code-prompts-and-deliveries/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The accepted MVP scope makes Code Prompts and Deliveries the central differentiator: learners should prove they can ship coherent engineering work, not only solve isolated exercises. The current baseline has lesson challenges and progression, but it does not yet define Code Prompt anatomy, workspace lifecycle, Delivery submission, evaluation, revision, review reports, learner evidence, or the boundary with future B2B hiring assessments.
+
+## What Changes
+
+- Add a new `academy-code-prompts-deliveries` capability for project-style prompts and submitted Deliveries.
+- Define Code Prompt anatomy: mission brief, objective, constraints, starter project/workspace instructions, delivery checklist, and evaluation expectations.
+- Define prompt workspace lifecycle: start, resume, preserve work, reset/restart, and state ownership.
+- Define Delivery submission: project/code changes, implementation notes, assumptions, tradeoffs, tests, screenshots, and other prompt-required evidence.
+- Define attempt history, evaluation checks, basic review reports, revision flow, and accepted Delivery evidence.
+- Integrate accepted Deliveries with learner progress, basic skill evidence, and mission-log activity.
+- Preserve compatibility with future hiring assessments while explicitly deferring company tenants, candidate packets, anti-cheating, rubric editors, and custom prompt libraries.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-code-prompts-deliveries`: Code Prompt definitions, prompt workspaces, Delivery submissions, attempts, evaluation checks, review reports, revisions, learner evidence, and future hiring-assessment boundaries.
+
+### Modified Capabilities
+
+- `academy-lesson-challenge`: Clarify the boundary between focused lesson challenges and broader Code Prompts.
+- `academy-progression`: Include accepted Deliveries as learner evidence without making progression own prompt evaluation internals.
+- `academy-mission-log`: Include prompt and Delivery lifecycle events as loggable activity without making mission-log own prompt behavior.
+
+## Impact
+
+- Affects future learner web, admin/content, API/contracts, code runner, and content health proposals.
+- Adds no implementation code in this proposal.
+- Does not define B2B hiring assessments, company accounts, rubric editor tooling, plagiarism detection, or prompt authoring UI in detail.
+- Future implementation proposals should reference this capability before scaffolding Code Prompt screens, APIs, data models, or runner integration.

--- a/openspec/changes/define-academy-code-prompts-and-deliveries/specs/academy-code-prompts-deliveries/spec.md
+++ b/openspec/changes/define-academy-code-prompts-and-deliveries/specs/academy-code-prompts-deliveries/spec.md
@@ -1,0 +1,231 @@
+## ADDED Requirements
+
+### Requirement: Code Prompt Anatomy
+The system SHALL define Code Prompts as mission-framed, project-style assignments that ask learners to ship a coherent engineering Delivery.
+
+#### Scenario: Prompt brief is presented
+GIVEN a learner opens a Code Prompt
+WHEN the prompt renders
+THEN the system presents a mission brief
+AND presents the objective
+AND presents constraints
+AND presents starter project or workspace instructions
+AND presents a Delivery checklist
+AND presents evaluation expectations.
+
+#### Scenario: Prompt supports different starting points
+GIVEN a Code Prompt is configured
+WHEN the prompt defines its starting point
+THEN the prompt may start from a blank workspace, a starter project, a partial implementation, a failing project, or a refactoring target
+AND the prompt identifies what the learner is expected to take to delivery.
+
+#### Scenario: Prompt preserves CYOA framing
+GIVEN a Code Prompt is displayed
+WHEN mission language is applied
+THEN the prompt frames work as an operation, incident, client request, field assignment, architecture review, or delivery mission
+AND does not obscure the technical objective.
+
+### Requirement: Prompt Workspace Lifecycle
+The system SHALL provide a learner workspace lifecycle for starting, resuming, preserving, resetting, and submitting Code Prompt work.
+
+#### Scenario: Start workspace
+GIVEN a learner starts a Code Prompt
+WHEN no active workspace exists for that learner and prompt
+THEN the system creates a workspace from the prompt starting point
+AND associates it with the learner, prompt, and attempt.
+
+#### Scenario: Resume workspace
+GIVEN a learner has an active prompt workspace
+WHEN the learner returns to the prompt
+THEN the system restores the latest saved workspace state
+AND preserves learner work until the learner resets, submits, or the workspace expires according to product policy.
+
+#### Scenario: Reset workspace
+GIVEN a learner has an active prompt workspace
+WHEN the learner resets the workspace
+THEN the system starts from the configured prompt starting point
+AND preserves prior attempt history separately from the new workspace state.
+
+#### Scenario: Workspace failure
+GIVEN workspace state cannot be loaded or saved
+WHEN the learner opens or edits the prompt workspace
+THEN the system displays recoverable feedback
+AND avoids silently discarding learner work.
+
+### Requirement: Delivery Submission
+The system SHALL allow learners to submit a Delivery that contains the work and evidence required by a Code Prompt.
+
+#### Scenario: Submit Delivery
+GIVEN a learner has completed prompt work
+WHEN the learner submits a Delivery
+THEN the system records the submitted code or project changes
+AND records implementation notes when provided
+AND records assumptions or tradeoffs when provided
+AND records required evidence defined by the prompt
+AND associates the Delivery with the learner, prompt, workspace, and attempt.
+
+#### Scenario: Required evidence missing
+GIVEN a prompt requires specific Delivery evidence
+WHEN the learner submits without that evidence
+THEN the system blocks submission
+AND identifies the missing Delivery requirements.
+
+#### Scenario: Delivery snapshot
+GIVEN a Delivery is submitted
+WHEN evaluation begins
+THEN the system evaluates a stable snapshot of the submitted work
+AND later workspace edits do not mutate the evaluated Delivery snapshot.
+
+### Requirement: Attempt History
+The system SHALL maintain Code Prompt attempt history across workspace resets, Delivery submissions, evaluations, and revisions.
+
+#### Scenario: Attempt timeline
+GIVEN a learner works on a Code Prompt
+WHEN the learner starts, submits, revises, resets, or receives evaluation feedback
+THEN the system records the event in prompt attempt history
+AND includes timestamp, status, prompt, learner, and relevant Delivery or evaluation identifiers.
+
+#### Scenario: Attempt history remains available
+GIVEN a learner has previous prompt attempts
+WHEN the learner views the prompt history
+THEN the system displays previous statuses, submitted Deliveries, evaluation summaries, and revision outcomes available to that learner.
+
+#### Scenario: Attempt history supports admin visibility
+GIVEN an authorized admin or instructor reviews learner prompt progress
+WHEN prompt attempt history is requested
+THEN the system exposes attempt status, evaluation summary, and timestamps needed for support or content health review
+AND does not expose private learner data outside the authorized scope.
+
+### Requirement: Evaluation Checks
+The system SHALL evaluate Deliveries using configured checks appropriate to the prompt and record the results.
+
+#### Scenario: Delivery checks run
+GIVEN a Delivery is submitted
+WHEN evaluation starts
+THEN the system runs configured checks such as tests, hidden tests, lint, typecheck, build, static checks, or prompt-specific evaluation steps
+AND records check status and output.
+
+#### Scenario: Evaluation pending
+GIVEN evaluation is still running
+WHEN the learner views the Delivery
+THEN the system displays pending evaluation state
+AND prevents the pending state from being mistaken for accepted or failed.
+
+#### Scenario: Evaluation failure
+GIVEN evaluation infrastructure fails
+WHEN the Delivery cannot be evaluated
+THEN the system records an evaluation error
+AND provides retry or support guidance without marking the Delivery as accepted.
+
+#### Scenario: Hidden checks remain protected
+GIVEN a prompt uses hidden checks
+WHEN evaluation results are displayed
+THEN the system reports outcome and actionable feedback
+AND does not reveal hidden check implementation details that would compromise the prompt.
+
+### Requirement: Basic Review Report
+The system SHALL provide a basic review report for evaluated Deliveries with status, check outcomes, feedback, and revision guidance.
+
+#### Scenario: Accepted Delivery report
+GIVEN a Delivery passes required evaluation
+WHEN the review report is displayed
+THEN the report shows accepted status
+AND summarizes passed checks or strengths
+AND records the accepted Delivery as learner evidence.
+
+#### Scenario: Needs revision report
+GIVEN a Delivery is close but does not meet all prompt expectations
+WHEN the review report is displayed
+THEN the report shows needs-revision status
+AND identifies failed checks, risks, missing evidence, or improvement guidance
+AND allows the learner to revise and resubmit.
+
+#### Scenario: Failed Delivery report
+GIVEN a Delivery cannot satisfy required evaluation
+WHEN the review report is displayed
+THEN the report shows failed status
+AND provides actionable feedback when available
+AND preserves the failed Delivery in attempt history.
+
+#### Scenario: Review report uses mission consequences
+GIVEN review feedback is displayed
+WHEN the prompt uses mission framing
+THEN the report may describe consequences, risk, or unlocked follow-up work
+AND keeps technical feedback clear and actionable.
+
+### Requirement: Revision Flow
+The system SHALL support revising a Delivery after evaluation feedback while preserving prior evaluated snapshots.
+
+#### Scenario: Revise Delivery
+GIVEN a Delivery receives needs-revision or failed status
+WHEN the learner chooses to revise
+THEN the system returns the learner to the associated workspace or a revision workspace
+AND preserves the prior Delivery snapshot and review report.
+
+#### Scenario: Resubmit revision
+GIVEN a learner revises prompt work
+WHEN the learner resubmits
+THEN the system creates a new evaluated Delivery or revision attempt linked to the prompt history
+AND does not overwrite prior evaluation history.
+
+#### Scenario: Accepted revision
+GIVEN a revised Delivery is accepted
+WHEN learner evidence is updated
+THEN the system records the accepted revision as the current accepted Delivery for the prompt
+AND preserves earlier attempts for learning history.
+
+### Requirement: Learner Evidence Integration
+The system SHALL integrate accepted Deliveries into learner progress, basic skill evidence, and mission activity without making those capabilities own prompt evaluation internals.
+
+#### Scenario: Progress evidence updated
+GIVEN a Delivery is accepted
+WHEN learner progress is updated
+THEN the system records the accepted Delivery against the learner's progress
+AND associates configured skill tags or path progress evidence.
+
+#### Scenario: Mission log entry
+GIVEN a Delivery changes status
+WHEN status is accepted, needs revision, failed, or evaluation error
+THEN the system may create a mission-log transmission or activity entry
+AND links the entry back to the relevant prompt, Delivery, or review report.
+
+#### Scenario: Evidence boundary
+GIVEN progression or mission-log surfaces display Delivery information
+WHEN they render Delivery evidence
+THEN they display derived status and links
+AND do not own prompt workspace, evaluation, or review report behavior.
+
+### Requirement: Future Hiring Assessment Boundary
+The system SHALL preserve compatibility with future hiring assessments while keeping company assessment workflows out of learner MVP scope.
+
+#### Scenario: B2B workflow deferred
+GIVEN a feature requires company tenants, candidate assignment links, candidate review packets, anti-cheating, plagiarism checks, custom company prompt libraries, or rubric editor workflows
+WHEN the feature is proposed during learner MVP work
+THEN it is classified as future/B2B
+AND requires a separate OpenSpec proposal before implementation.
+
+#### Scenario: Shared foundation preserved
+GIVEN Code Prompt and Delivery behavior is designed
+WHEN future hiring assessment needs are considered
+THEN prompt, Delivery, evaluation, review, and attempt concepts remain general enough to support future candidate assessment use
+AND learner MVP workflows are not forced to expose company assessment features.
+
+### Requirement: Code Prompts Responsibility Boundary
+The Code Prompts and Deliveries capability SHALL own prompt anatomy, workspace lifecycle, Delivery submission, prompt attempts, evaluation checks, review reports, revision flow, and prompt evidence boundaries.
+
+#### Scenario: Lesson challenge delegates broad prompts
+GIVEN a learning activity requires project-style Delivery evidence or multi-step prompt evaluation
+WHEN the activity exceeds focused lesson challenge behavior
+THEN the lesson challenge capability delegates that activity to Code Prompts and Deliveries.
+
+#### Scenario: Progression consumes accepted evidence
+GIVEN a Delivery is accepted
+WHEN progression updates
+THEN progression consumes accepted Delivery evidence
+AND Code Prompts and Deliveries remains authoritative for prompt evaluation and review report details.
+
+#### Scenario: Mission log consumes status events
+GIVEN prompt or Delivery status changes
+WHEN mission-log activity is created
+THEN mission-log consumes prompt lifecycle events
+AND Code Prompts and Deliveries remains authoritative for prompt, workspace, Delivery, evaluation, and revision behavior.

--- a/openspec/changes/define-academy-code-prompts-and-deliveries/specs/academy-lesson-challenge/spec.md
+++ b/openspec/changes/define-academy-code-prompts-and-deliveries/specs/academy-lesson-challenge/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Lesson Challenge Code Prompt Boundary
+The lesson challenge capability SHALL own focused lesson-level coding challenges and SHALL delegate project-style prompt work to the Code Prompts and Deliveries capability.
+
+#### Scenario: Focused challenge remains lesson-owned
+GIVEN a learner works on a lesson challenge
+WHEN the activity evaluates a focused exercise, code pane, acceptance checklist, test run, draft, or mentor interaction local to the lesson
+THEN academy-lesson-challenge owns the challenge behavior.
+
+#### Scenario: Project-style prompt delegates
+GIVEN a learner activity requires a mission brief, starter project, Delivery checklist, implementation notes, broad evidence, review report, or revision lifecycle
+WHEN the activity is presented from a lesson or path
+THEN academy-lesson-challenge delegates that activity to academy-code-prompts-deliveries.
+
+#### Scenario: Lesson can link to prompt
+GIVEN a lesson introduces a Code Prompt
+WHEN the learner activates the prompt entry point
+THEN the lesson challenge surface may navigate to or embed the Code Prompt entry point
+AND does not own prompt workspace, Delivery evaluation, or review report behavior.

--- a/openspec/changes/define-academy-code-prompts-and-deliveries/specs/academy-mission-log/spec.md
+++ b/openspec/changes/define-academy-code-prompts-and-deliveries/specs/academy-mission-log/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Prompt Delivery Activity Boundary
+The mission-log capability SHALL display prompt and Delivery lifecycle activity while delegating prompt behavior to Code Prompts and Deliveries.
+
+#### Scenario: Delivery activity appears in mission log
+GIVEN a Delivery is submitted, accepted, marked needs revision, failed, or encounters evaluation error
+WHEN mission-log activity is generated
+THEN academy-mission-log may display a transmission for the prompt or Delivery event
+AND links to the relevant prompt, Delivery, or review report.
+
+#### Scenario: Mission log does not own prompt state
+GIVEN a learner interacts with a Delivery-related mission-log transmission
+WHEN the learner follows the transmission action
+THEN academy-mission-log routes to the Code Prompt or review report destination
+AND does not mutate prompt workspace, evaluation, review, or revision state.
+
+#### Scenario: Prompt activity respects visibility
+GIVEN prompt or Delivery activity is shown to learners, admins, or instructors
+WHEN mission-log data is requested
+THEN academy-mission-log shows only activity the viewer is authorized to access
+AND relies on the owning capability for prompt and Delivery visibility rules.

--- a/openspec/changes/define-academy-code-prompts-and-deliveries/specs/academy-progression/spec.md
+++ b/openspec/changes/define-academy-code-prompts-and-deliveries/specs/academy-progression/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Delivery Evidence Progression Boundary
+The progression capability SHALL consume accepted Delivery evidence for learner progress while delegating prompt evaluation and review details to Code Prompts and Deliveries.
+
+#### Scenario: Accepted Delivery contributes progress
+GIVEN a learner has an accepted Delivery
+WHEN progression state is calculated
+THEN academy-progression may count the accepted Delivery toward path progress, skill evidence, achievements, or clearance requirements
+AND uses Delivery status provided by academy-code-prompts-deliveries.
+
+#### Scenario: Non-accepted Delivery does not complete progress
+GIVEN a Delivery has pending, needs-revision, failed, or evaluation-error status
+WHEN progression state is calculated
+THEN academy-progression does not treat that Delivery as accepted completion evidence
+AND may display the derived status without owning the review report.
+
+#### Scenario: Progression delegates review detail
+GIVEN a learner views progress evidence from an accepted Delivery
+WHEN the learner opens review details
+THEN academy-progression links to the prompt review report
+AND academy-code-prompts-deliveries remains authoritative for evaluation checks, feedback, and revision history.

--- a/openspec/changes/define-academy-code-prompts-and-deliveries/tasks.md
+++ b/openspec/changes/define-academy-code-prompts-and-deliveries/tasks.md
@@ -1,0 +1,24 @@
+## 1. Proposal Review
+
+- [ ] 1.1 Review `academy-mvp-scope`, `academy-lesson-challenge`, `academy-progression`, and `academy-mission-log` baseline specs for prompt and Delivery touchpoints.
+- [ ] 1.2 Review `docs/product/code-prompts-deliveries-and-learning-differentiators.md` for product terminology and future/B2B boundaries.
+- [ ] 1.3 Confirm Code Prompts and Deliveries remain learner-MVP focused while preserving future hiring-assessment compatibility.
+
+## 2. Spec Application
+
+- [ ] 2.1 Add the accepted `academy-code-prompts-deliveries` capability to baseline specs.
+- [ ] 2.2 Update `academy-lesson-challenge` with the focused challenge versus Code Prompt boundary.
+- [ ] 2.3 Update `academy-progression` with accepted Delivery evidence boundaries.
+- [ ] 2.4 Update `academy-mission-log` with prompt and Delivery activity boundaries.
+
+## 3. Follow-Up Planning
+
+- [ ] 3.1 Update follow-up proposal roadmap if needed to sequence admin prompt authoring, prompt workspace UX, API/contracts, runner evaluation, and content health work.
+- [ ] 3.2 Identify which implementation or deeper specification proposal should come after this proposal is accepted.
+- [ ] 3.3 Confirm no application implementation code is included in this capability-definition change.
+
+## 4. Validation
+
+- [ ] 4.1 Run `openspec validate define-academy-code-prompts-and-deliveries --strict`.
+- [ ] 4.2 Run `openspec validate --all --strict`.
+- [ ] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.


### PR DESCRIPTION
## Summary
- add OpenSpec proposal define-academy-code-prompts-and-deliveries
- introduce the academy-code-prompts-deliveries capability delta
- define Code Prompt anatomy, workspace lifecycle, Delivery submission, attempts, evaluation checks, review reports, revisions, and learner evidence
- add boundary deltas for lesson challenge, progression, and mission log
- preserve future B2B hiring assessment compatibility while deferring B2B workflows

## Verification
- openspec validate define-academy-code-prompts-and-deliveries --strict
- openspec validate --all --strict
- git diff --check

This is planning/specification only; no implementation scaffolding is included.