### PR TITLE
docs: apply academy admin content management spec

### DIFF
--- a/docs/openspec-follow-up-proposals.md
+++ b/docs/openspec-follow-up-proposals.md
@@ -10,12 +10,12 @@ and `academy-mvp-scope`.
    - Keep hiring assessments out of MVP while preserving a compatible foundation.
    - Depends on `academy-mvp-scope`.
 
-2. `define-academy-admin-content-management` (next)
+2. `define-academy-admin-content-management` (accepted)
    - Define admin authoring for tracks, courses, modules, lessons, challenges, Code Prompts, preview, and publish/unpublish.
    - Establish the minimum content operations needed to run the first shippable path.
    - Depends on `academy-mvp-scope`.
 
-3. `define-academy-content-health-dashboard`
+3. `define-academy-content-health-dashboard` (next)
    - Define instructor/admin visibility into stuck learners, failed attempts, prompt delivery outcomes, and content quality signals.
    - Depends on `academy-mvp-scope`.
 
@@ -57,6 +57,6 @@ and `academy-mvp-scope`.
 
 ## First Implementation Recommendation
 
-Start with `define-academy-admin-content-management`.
+Start with `define-academy-content-health-dashboard`.
 
-Reason: `academy-code-prompts-deliveries` now defines the learner prompt and Delivery loop. Admin content management should come next so tracks, courses, lessons, challenges, Code Prompts, preview, and publishing are specified before implementation scaffolding.
+Reason: `academy-code-prompts-deliveries` defines the learner prompt and Delivery loop, and `academy-admin-content-management` defines how that content is authored and published. Content health should come next so failed attempts, stuck signals, and Delivery outcomes are specified before implementation scaffolding hardens the data shape.

--- a/openspec/changes/define-academy-admin-content-management/tasks.md
+++ b/openspec/changes/define-academy-admin-content-management/tasks.md
@@ -1,25 +1,25 @@
 ## 1. Proposal Review
 
-- [ ] 1.1 Review `academy-mvp-scope`, `academy-catalog`, `academy-lesson-challenge`, and `academy-code-prompts-deliveries` for content source boundaries.
-- [ ] 1.2 Review the follow-up proposal roadmap and confirm admin content management is the next needed capability before implementation scaffolding.
-- [ ] 1.3 Confirm admin content management stays MVP-focused and does not absorb content health analytics or advanced CMS workflows.
+- [x] 1.1 Review `academy-mvp-scope`, `academy-catalog`, `academy-lesson-challenge`, and `academy-code-prompts-deliveries` for content source boundaries.
+- [x] 1.2 Review the follow-up proposal roadmap and confirm admin content management is the next needed capability before implementation scaffolding.
+- [x] 1.3 Confirm admin content management stays MVP-focused and does not absorb content health analytics or advanced CMS workflows.
 
 ## 2. Spec Application
 
-- [ ] 2.1 Add the accepted `academy-admin-content-management` capability to baseline specs.
-- [ ] 2.2 Update `academy-catalog` with published content consumption boundaries.
-- [ ] 2.3 Update `academy-lesson-challenge` with published lesson/challenge content boundaries.
-- [ ] 2.4 Update `academy-code-prompts-deliveries` with published prompt definition boundaries.
-- [ ] 2.5 Update `academy-mvp-scope` with admin content operations boundaries.
+- [x] 2.1 Add the accepted `academy-admin-content-management` capability to baseline specs.
+- [x] 2.2 Update `academy-catalog` with published content consumption boundaries.
+- [x] 2.3 Update `academy-lesson-challenge` with published lesson/challenge content boundaries.
+- [x] 2.4 Update `academy-code-prompts-deliveries` with published prompt definition boundaries.
+- [x] 2.5 Update `academy-mvp-scope` with admin content operations boundaries.
 
 ## 3. Follow-Up Planning
 
-- [ ] 3.1 Update follow-up proposal roadmap if needed after admin content management is accepted.
-- [ ] 3.2 Identify whether content health dashboard or AI mentor guardrails should come next.
-- [ ] 3.3 Confirm no application implementation code is included in this capability-definition change.
+- [x] 3.1 Update follow-up proposal roadmap if needed after admin content management is accepted.
+- [x] 3.2 Identify whether content health dashboard or AI mentor guardrails should come next.
+- [x] 3.3 Confirm no application implementation code is included in this capability-definition change.
 
 ## 4. Validation
 
-- [ ] 4.1 Run `openspec validate define-academy-admin-content-management --strict`.
-- [ ] 4.2 Run `openspec validate --all --strict`.
-- [ ] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.
+- [x] 4.1 Run `openspec validate define-academy-admin-content-management --strict`.
+- [x] 4.2 Run `openspec validate --all --strict`.
+- [x] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.

--- a/openspec/specs/academy-admin-content-management/spec.md
+++ b/openspec/specs/academy-admin-content-management/spec.md
@@ -1,0 +1,200 @@
+# Academy Admin Content Management Specification
+
+## Purpose
+
+Define the Presstronic Academy admin content management capability.
+
+This specification captures admin/instructor authoring, validation, preview, review, publishing, unpublishing, archiving, restoration, versioning, rollback, role boundaries, and consumption boundaries for tracks, courses, modules, lessons, focused coding challenges, Code Prompts, and catalog metadata. It does not specify final database schemas, REST endpoints, rich text editor implementation, media storage, workflow notifications, content health analytics, or advanced CMS collaboration workflows.
+
+## Requirements
+
+### Requirement: Managed Content Types
+The system SHALL allow authorized admins to manage the structured content types required for the first shippable Academy path.
+
+#### Scenario: Content types are available
+GIVEN an authorized admin opens content management
+WHEN the admin creates or edits content
+THEN the system supports tracks, courses, modules, lessons, focused coding challenges, Code Prompts, and catalog metadata
+AND identifies relationships between those content types.
+
+#### Scenario: Mission framing metadata
+GIVEN an admin edits learner-facing content
+WHEN the content supports mission framing
+THEN the system allows mission title, brief, objective, constraints, and learner-facing operation language where applicable
+AND keeps mission framing separate from validation-critical technical requirements.
+
+#### Scenario: Relationship integrity
+GIVEN content references another content item
+WHEN the admin saves or validates the content
+THEN the system detects missing, invalid, archived, or incompatible references
+AND prevents publishing content with broken required relationships.
+
+### Requirement: Content Lifecycle
+The system SHALL manage content through draft, review, published, unpublished, archived, and restored states.
+
+#### Scenario: Draft content
+GIVEN an authorized author creates content
+WHEN the content is saved
+THEN the system stores it as draft by default
+AND draft content is not visible to normal learners.
+
+#### Scenario: Submit for review
+GIVEN draft content passes required validation
+WHEN an author submits it for review
+THEN the system marks the content as in review
+AND preserves the draft version being reviewed.
+
+#### Scenario: Publish content
+GIVEN content is in review and passes publish validation
+WHEN an authorized publisher publishes it
+THEN the system creates a published version
+AND makes the content available to learner-facing capabilities according to access rules.
+
+#### Scenario: Unpublish content
+GIVEN content is published
+WHEN an authorized publisher unpublishes it
+THEN the system removes it from normal learner discovery
+AND preserves existing learner history that references prior published versions.
+
+#### Scenario: Archive and restore content
+GIVEN content should no longer be edited or selected for new paths
+WHEN an authorized admin archives it
+THEN the system marks it archived
+AND allows an authorized admin to restore it when product policy permits.
+
+### Requirement: Content Validation
+The system SHALL validate content for required fields, structure, references, publish readiness, and learner-surface compatibility.
+
+#### Scenario: Required fields
+GIVEN an admin saves or submits content
+WHEN required title, slug, summary, body, relationship, mission, challenge, prompt, or catalog fields are missing
+THEN the system identifies the missing fields
+AND prevents review or publish when publish-critical fields are incomplete.
+
+#### Scenario: Lesson validation
+GIVEN an admin validates a lesson
+WHEN lesson content contains invalid structure, missing objectives, broken media references, or unsupported learner-rendering blocks
+THEN the system reports validation issues
+AND prevents publishing until publish-critical issues are resolved.
+
+#### Scenario: Focused challenge validation
+GIVEN an admin validates a focused coding challenge
+WHEN starter code, acceptance criteria, test definitions, reward metadata, or sandbox configuration is incomplete or invalid
+THEN the system reports validation issues
+AND prevents publishing until the focused challenge is runnable or explicitly marked unavailable by product policy.
+
+#### Scenario: Code Prompt validation
+GIVEN an admin validates a Code Prompt
+WHEN mission brief, objective, constraints, starting point, Delivery checklist, required evidence, or evaluation expectations are incomplete
+THEN the system reports validation issues
+AND prevents publishing until the prompt can support a learner Delivery workflow.
+
+### Requirement: Preview
+The system SHALL allow authorized admins to preview learner-facing content before publication.
+
+#### Scenario: Catalog preview
+GIVEN an admin previews a track, course, module, or catalog offering
+WHEN preview renders
+THEN the system shows how the offering will appear in learner catalog or dashboard contexts
+AND indicates that the preview is not published learner content.
+
+#### Scenario: Lesson and challenge preview
+GIVEN an admin previews a lesson or focused coding challenge
+WHEN preview renders
+THEN the system uses learner-facing layout and rendering rules where feasible
+AND displays validation or availability warnings separately from learner content.
+
+#### Scenario: Code Prompt preview
+GIVEN an admin previews a Code Prompt
+WHEN preview renders
+THEN the system shows the mission brief, objective, constraints, starting point instructions, Delivery checklist, and evaluation expectations
+AND does not create a learner attempt or workspace.
+
+### Requirement: Versioning and Rollback
+The system SHALL preserve content versions, publish history, change notes, and rollback targets for published content.
+
+#### Scenario: Version is created
+GIVEN content is published
+WHEN the publication succeeds
+THEN the system records a published version identifier
+AND records publisher, timestamp, and change notes when provided.
+
+#### Scenario: Edit published content
+GIVEN content has a published version
+WHEN an admin edits it
+THEN the system creates or updates a draft without mutating the published version
+AND learner-facing surfaces continue using the current published version until a new version is published.
+
+#### Scenario: Roll back content
+GIVEN a previous published version exists
+WHEN an authorized publisher rolls back
+THEN the system restores that version as the active published version
+AND records the rollback event in publish history.
+
+### Requirement: Admin Roles
+The system SHALL distinguish authoring, review, publishing, and read-only permissions for content management.
+
+#### Scenario: Author permissions
+GIVEN a user has author permission
+WHEN the user works in content management
+THEN the system allows creating and editing drafts
+AND does not allow publishing unless the user also has publisher permission.
+
+#### Scenario: Reviewer permissions
+GIVEN a user has reviewer permission
+WHEN content is in review
+THEN the system allows review feedback, approval, or request-changes actions according to product policy
+AND does not require the reviewer to own the draft.
+
+#### Scenario: Publisher permissions
+GIVEN a user has publisher permission
+WHEN content passes publish validation
+THEN the system allows publishing, unpublishing, rollback, archive, and restore actions according to product policy.
+
+#### Scenario: Read-only permissions
+GIVEN a user has read-only admin permission
+WHEN the user opens content management
+THEN the system allows viewing content, validation results, previews, and publish history
+AND prevents mutation actions.
+
+### Requirement: Published Content Consumption Boundary
+The admin content management capability SHALL own authoring, validation, preview, lifecycle, versioning, and publication while learner-facing capabilities consume published content.
+
+#### Scenario: Catalog consumes published offerings
+GIVEN content is published for learner discovery
+WHEN catalog renders offerings
+THEN catalog consumes the published offering data
+AND does not own draft authoring, validation, or publication behavior.
+
+#### Scenario: Lesson challenge consumes published lesson content
+GIVEN a learner opens a lesson or focused challenge
+WHEN lesson challenge renders
+THEN lesson challenge consumes the published lesson and challenge version
+AND does not own admin authoring or publish lifecycle.
+
+#### Scenario: Code Prompts consume published prompt definitions
+GIVEN a learner opens a Code Prompt
+WHEN Code Prompts and Deliveries initializes the prompt
+THEN it consumes the published prompt definition
+AND does not own admin authoring, validation, preview, or publication behavior.
+
+### Requirement: Admin Content Management Responsibility Boundary
+The admin content management capability SHALL own content operations for MVP authoring and SHALL delegate learner experience, learner outcomes, and content health analytics to their owning capabilities.
+
+#### Scenario: Learner surface boundary
+GIVEN authored content is published
+WHEN a learner interacts with it
+THEN the learner-facing capability owns the learner interaction behavior
+AND admin content management owns the content source, version, and publication state.
+
+#### Scenario: Content health boundary
+GIVEN learner attempts, failures, stuck signals, Delivery outcomes, or drop-off metrics are analyzed
+WHEN content health is displayed
+THEN content health dashboard owns health signal presentation
+AND admin content management owns content identity and version context.
+
+#### Scenario: Auth boundary
+GIVEN a user performs content management actions
+WHEN permissions are checked
+THEN authentication and authorization systems provide identity and permission decisions
+AND admin content management applies those decisions to content actions.

--- a/openspec/specs/academy-catalog/spec.md
+++ b/openspec/specs/academy-catalog/spec.md
@@ -406,3 +406,23 @@ The catalog capability SHALL own offering discovery, filters, offering cards, ca
 - **WHEN** navigation begins
 - **THEN** catalog initiates the route
 - **AND** academy-lesson-challenge owns test execution, draft safety, and sandbox behavior.
+
+### Requirement: Catalog Published Content Boundary
+The catalog capability SHALL consume published catalog offerings from admin content management and SHALL NOT own content authoring, validation, preview, publication, or versioning.
+
+#### Scenario: Catalog displays published offerings
+GIVEN admin content management has published catalog offerings
+WHEN catalog renders available offerings
+THEN catalog displays published offering data according to learner access rules
+AND does not display draft, in-review, archived, or unpublished content to normal learners.
+
+#### Scenario: Catalog links to content version
+GIVEN a learner opens a catalog offering
+WHEN the offering starts a path, course, lesson, challenge, or Code Prompt
+THEN catalog routes to the learner-facing destination using the published content identity or version needed by that destination.
+
+#### Scenario: Catalog delegates authoring
+GIVEN an admin needs to create, edit, preview, publish, unpublish, or archive an offering
+WHEN the admin performs content operations
+THEN those operations belong to academy-admin-content-management
+AND catalog remains responsible only for learner-facing discovery, filtering, and navigation.

--- a/openspec/specs/academy-code-prompts-deliveries/spec.md
+++ b/openspec/specs/academy-code-prompts-deliveries/spec.md
@@ -237,3 +237,24 @@ GIVEN prompt or Delivery status changes
 WHEN mission-log activity is created
 THEN mission-log consumes prompt lifecycle events
 AND Code Prompts and Deliveries remains authoritative for prompt, workspace, Delivery, evaluation, and revision behavior.
+
+### Requirement: Code Prompt Published Definition Boundary
+The Code Prompts and Deliveries capability SHALL consume published Code Prompt definitions from admin content management and SHALL NOT own prompt authoring, validation, preview, publication, or versioning.
+
+#### Scenario: Prompt uses published definition
+GIVEN a learner opens a Code Prompt
+WHEN the prompt initializes
+THEN Code Prompts and Deliveries uses the published prompt definition selected for that learner path
+AND creates learner workspace, Delivery, attempt, evaluation, and review behavior from that published definition.
+
+#### Scenario: Draft prompt excluded from learner workflow
+GIVEN a Code Prompt exists only as draft, in review, archived, or unpublished
+WHEN a normal learner requests it
+THEN Code Prompts and Deliveries does not create a learner workspace or Delivery flow for that prompt
+AND follows not-found, unavailable, or access behavior defined by learner-facing specs.
+
+#### Scenario: Prompt authoring delegated
+GIVEN an admin edits mission brief, objective, constraints, starting point, Delivery checklist, required evidence, or evaluation expectations
+WHEN the edit is saved, validated, previewed, or published
+THEN academy-admin-content-management owns that prompt-definition operation
+AND Code Prompts and Deliveries consumes the resulting published definition.

--- a/openspec/specs/academy-lesson-challenge/spec.md
+++ b/openspec/specs/academy-lesson-challenge/spec.md
@@ -345,3 +345,24 @@ GIVEN a lesson introduces a Code Prompt
 WHEN the learner activates the prompt entry point
 THEN the lesson challenge surface may navigate to or embed the Code Prompt entry point
 AND does not own prompt workspace, Delivery evaluation, or review report behavior.
+
+### Requirement: Lesson Challenge Published Content Boundary
+The lesson challenge capability SHALL consume published lesson and focused challenge content from admin content management and SHALL NOT own admin authoring or publish lifecycle.
+
+#### Scenario: Lesson renders published version
+GIVEN a learner opens a lesson challenge
+WHEN lesson content renders
+THEN the lesson challenge uses the published lesson and challenge version selected for that learner path
+AND preserves learner attempts against that version.
+
+#### Scenario: Draft content excluded from learner challenge
+GIVEN a lesson or challenge exists only as draft, in review, archived, or unpublished
+WHEN a normal learner requests it
+THEN the lesson challenge does not render it as available learner content
+AND follows not-found, unavailable, or access behavior defined by learner-facing specs.
+
+#### Scenario: Authoring delegated
+GIVEN an admin edits lesson body, starter code, tests, acceptance criteria, or challenge metadata
+WHEN the edit is saved, validated, previewed, or published
+THEN academy-admin-content-management owns that content operation
+AND lesson challenge consumes the resulting published content.

--- a/openspec/specs/academy-mvp-scope/spec.md
+++ b/openspec/specs/academy-mvp-scope/spec.md
@@ -157,3 +157,23 @@ GIVEN contributors disagree about whether a feature belongs in MVP
 WHEN the feature is reviewed
 THEN the decision is made by whether the feature is required to prove the first shippable learning loop
 AND the feature is deferred when it adds breadth without strengthening that loop.
+
+### Requirement: MVP Admin Content Operations Boundary
+The MVP scope SHALL treat admin content management as required operational scope for the first shippable path.
+
+#### Scenario: Admin content management remains MVP-critical
+GIVEN MVP implementation planning begins
+WHEN the first shippable learner path is planned
+THEN admin content management is included as MVP-critical operational scope
+AND supports authoring, validating, previewing, publishing, unpublishing, and versioning the content needed for that path.
+
+#### Scenario: Advanced CMS features remain deferred
+GIVEN advanced CMS features such as localization, scheduled releases, media pipelines, full editorial assignments, or enterprise approval workflows are proposed
+WHEN MVP scope is enforced
+THEN those features are deferred unless a later proposal proves they are necessary for the first shippable path.
+
+#### Scenario: Content health remains separate
+GIVEN learner outcome signals need to be analyzed against content
+WHEN health dashboards are planned
+THEN content health dashboard remains a separate capability
+AND admin content management provides content identity and version context.


### PR DESCRIPTION
## Summary

- Applies the accepted `define-academy-admin-content-management` change into baseline OpenSpec specs.
- Adds the new baseline `academy-admin-content-management` capability.
- Adds published-content ownership boundaries to catalog, lesson challenge, Code Prompts and Deliveries, and MVP scope.
- Marks the change tasks complete and updates the follow-up roadmap to make content health dashboard the next proposal candidate.

## Notes

This is specification/documentation only. It does not include frontend, backend, storage, API, or infrastructure implementation.

## Verification

- `openspec validate define-academy-admin-content-management --strict`
- `openspec validate --all --strict`
- `git diff --check`