### PR TITLE
docs: propose academy content health dashboard

### DIFF
--- a/openspec/changes/define-academy-content-health-dashboard/.openspec.yaml
+++ b/openspec/changes/define-academy-content-health-dashboard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/define-academy-content-health-dashboard/README.md
+++ b/openspec/changes/define-academy-content-health-dashboard/README.md
@@ -1,0 +1,3 @@
+# define-academy-content-health-dashboard
+
+Define MVP-limited admin and instructor visibility into Academy content health using stuck learner signals, failed challenge attempts, Code Prompt Delivery outcomes, content version context, and privacy-aware aggregation.

--- a/openspec/changes/define-academy-content-health-dashboard/design.md
+++ b/openspec/changes/define-academy-content-health-dashboard/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The accepted MVP scope identifies content health as necessary operational support for the first shippable learning loop. Code Prompts and Deliveries define learner submissions, evaluation, review reports, revisions, and attempt history. Admin content management defines authoring, publication, content versions, and the boundary that content health owns learner outcome signal presentation.
+
+Content health should help an instructor or admin answer practical questions:
+
+- Where are learners getting stuck?
+- Which challenge tests fail repeatedly?
+- Which Code Prompts produce too many failed or needs-revision Deliveries?
+- Did a published content version improve or harm learner outcomes?
+- Which content should be reviewed before adding more material?
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define MVP-limited content health dashboards for admins and instructors.
+- Cover lessons, focused coding challenges, Code Prompts, tracks, courses, modules, and published content versions.
+- Define privacy-aware aggregate and learner-level support boundaries.
+- Define signal ownership boundaries with lesson challenge, Code Prompts and Deliveries, admin content management, learner dashboard, and privacy controls.
+- Preserve the Academy mission/CYOA tone in admin presentation without obscuring operational meaning.
+
+**Non-Goals:**
+
+- Do not implement UI, API endpoints, event pipelines, persistence, charting, alerting, or notification delivery.
+- Do not define a general analytics warehouse or BI platform.
+- Do not define adaptive content recommendations, automated remediation, or AI-generated content edits.
+- Do not expose hiring assessment analytics; B2B assessment workflows remain future scope.
+- Do not make learner-facing dashboard responsible for admin health views.
+
+## Decisions
+
+### Decision: Content health is operational, not general analytics
+
+The MVP dashboard should focus on actionable content quality signals needed to run and improve the first learning path. It should not become a broad analytics product before the learner loop ships.
+
+Alternative considered: define a full analytics platform with cohort segmentation, funnels, alerts, and exports. That would be useful later but too broad for MVP setup.
+
+### Decision: Health views use content version context
+
+Health signals should be tied to published content identity and version where available. This allows admins to see whether a specific publish caused improvement or regression without making authoring own health presentation.
+
+Alternative considered: aggregate all outcomes by content slug only. That is simpler but makes rollback and content iteration much harder to reason about.
+
+### Decision: Aggregate first, learner-level only for support
+
+The MVP should default to aggregate content health. Learner-level detail should exist only for authorized support/instructor use cases and should avoid exposing private profile, billing, or unrelated account data.
+
+Alternative considered: show all learner attempts by default. That is easier for small cohorts but creates a privacy habit that will not scale.
+
+### Decision: Source capabilities remain authoritative for raw outcomes
+
+Lesson challenge owns test execution and focused challenge attempt results. Code Prompts and Deliveries owns prompt attempts, Deliveries, evaluation checks, review reports, and revision lifecycle. Content health consumes those signals and presents patterns.
+
+Alternative considered: make content health compute or own attempt/evaluation state. That would blur product boundaries and duplicate learner workflow logic.
+
+## Risks / Trade-offs
+
+- Metrics can become misleading with low sample size -> MVP should show low-sample or incomplete-data states.
+- Privacy expectations can be missed early -> Define aggregate-first behavior and explicit learner-level access boundaries now.
+- Content health can expand into BI -> Keep only operational signals tied to content improvement in MVP.
+- Version-aware metrics require careful event shape later -> Capture the requirement now before contracts and persistence harden.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Apply the `academy-content-health-dashboard` baseline spec and boundary deltas.
+3. Create follow-up implementation proposals for admin frontend scaffolding, backend signal contracts, persistence/event shape, and dashboard query APIs.
+4. Keep AI mentor guardrails as the next proposal so mentor behavior is defined before live AI or authored-hint implementation.
+
+## Open Questions
+
+- What minimum sample size should hide or qualify content health metrics?
+- Which learner-level details are necessary for instructor support in MVP?
+- Should content health start with event-sourced facts, query tables, or implementation-defined storage?
+- Should content health include manual admin notes on content issues in MVP, or should that wait for content workflow tooling?

--- a/openspec/changes/define-academy-content-health-dashboard/proposal.md
+++ b/openspec/changes/define-academy-content-health-dashboard/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The MVP needs more than authored content and learner-facing execution. Admins and instructors need a limited way to see whether lessons, focused challenges, and Code Prompts are working: where learners get stuck, which tests fail repeatedly, which Deliveries need revision, and whether published content versions are producing weak outcomes.
+
+Without a defined content health capability, implementation scaffolding risks mixing analytics concerns into learner dashboards, content authoring, prompt evaluation, or challenge execution. This proposal gives content health a clear MVP boundary before frontend, API, storage, and contracts are scaffolded.
+
+## What Changes
+
+- Add a new `academy-content-health-dashboard` capability for privacy-aware admin/instructor visibility into content health.
+- Define MVP health signals for stuck learners, repeated challenge failures, sandbox/evaluation errors, Delivery outcomes, revision loops, drop-off points, and content version context.
+- Define dashboard summaries for tracks, courses, modules, lessons, focused challenges, and Code Prompts.
+- Define drill-down behavior that helps admins identify content needing review without turning the dashboard into a full analytics platform.
+- Define privacy and role boundaries for aggregated metrics and learner-level support views.
+- Add deltas so admin content management, lesson challenge, Code Prompts and Deliveries, dashboard, privacy controls, and MVP scope delegate or expose the correct content health responsibilities.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-content-health-dashboard`: Admin/instructor dashboard for content health signals, summaries, drill-downs, trend windows, content version context, privacy boundaries, and responsibility boundaries.
+
+### Modified Capabilities
+
+- `academy-admin-content-management`: Provides content identity and version context but does not own health signal presentation.
+- `academy-lesson-challenge`: Emits or exposes challenge attempt/test outcome signals but does not own health analysis.
+- `academy-code-prompts-deliveries`: Emits or exposes prompt attempt, Delivery, evaluation, review, and revision signals but does not own health analysis.
+- `academy-dashboard`: Remains learner-facing and does not expose admin content health.
+- `academy-privacy-controls`: Defines privacy expectations for learner data used in operational health views.
+- `academy-mvp-scope`: Recognizes content health as MVP-limited operational scope.
+
+## Impact
+
+- Affects future admin app, API/contracts, event design, persistence, and reporting implementation proposals.
+- Keeps MVP content health limited to actionable operational visibility rather than broad BI, cohort analytics, or adaptive learning automation.
+- Does not define final database schemas, event transport, metrics warehouse, charting libraries, alerting, notifications, or automated content recommendations.
+- Establishes `define-academy-ai-mentor-guardrails` as the next proposal candidate after this change is accepted.

--- a/openspec/changes/define-academy-content-health-dashboard/specs/academy-admin-content-management/spec.md
+++ b/openspec/changes/define-academy-content-health-dashboard/specs/academy-admin-content-management/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Content Health Context Boundary
+The admin content management capability SHALL provide content identity, lifecycle, and version context for content health while not owning health signal presentation or analytics.
+
+#### Scenario: Content identity provided to health
+GIVEN published content exists
+WHEN content health summarizes learner outcome signals
+THEN admin content management provides the content identity and published version context needed to attribute signals
+AND content health owns health summaries and drill-down presentation.
+
+#### Scenario: Health links back to authoring
+GIVEN an admin reviews a content health detail
+WHEN the admin opens the associated content record
+THEN admin content management owns the authoring, validation, preview, and publish workflow for any changes
+AND content health remains responsible only for health signal interpretation.
+
+#### Scenario: Health does not mutate content
+GIVEN content health identifies a weak lesson, challenge, or Code Prompt
+WHEN an admin reviews the signal
+THEN content health does not directly mutate content state
+AND any content revision, unpublish, rollback, or archive action belongs to admin content management.

--- a/openspec/changes/define-academy-content-health-dashboard/specs/academy-code-prompts-deliveries/spec.md
+++ b/openspec/changes/define-academy-content-health-dashboard/specs/academy-code-prompts-deliveries/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Code Prompt Health Signal Boundary
+The Code Prompts and Deliveries capability SHALL expose prompt attempt, Delivery, evaluation, review, revision, and accepted-evidence source facts for content health while not owning health aggregation or presentation.
+
+#### Scenario: Prompt outcomes available for health
+GIVEN learners work on Code Prompts
+WHEN content health requests prompt source facts
+THEN Code Prompts and Deliveries can provide prompt identity, published definition version when available, attempt status, workspace lifecycle events, Delivery status, evaluation outcomes, review report status, revision counts, accepted evidence status, and timestamps within authorized scope.
+
+#### Scenario: Health aggregation delegated
+GIVEN prompt and Delivery source facts exist
+WHEN accepted rates, needs-revision rates, failed Delivery rates, evaluation-error rates, or revision loops are displayed
+THEN content health owns aggregation and presentation
+AND Code Prompts and Deliveries remains authoritative for individual prompt, Delivery, evaluation, review, and revision facts.
+
+#### Scenario: Evaluation workflow unaffected by health
+GIVEN content health processing is delayed or unavailable
+WHEN a learner submits a Delivery or receives an evaluation result
+THEN Code Prompts and Deliveries preserves the learner workflow
+AND does not require the health dashboard to be available for prompt evaluation or review.

--- a/openspec/changes/define-academy-content-health-dashboard/specs/academy-content-health-dashboard/spec.md
+++ b/openspec/changes/define-academy-content-health-dashboard/specs/academy-content-health-dashboard/spec.md
@@ -1,0 +1,161 @@
+## ADDED Requirements
+
+### Requirement: Content Health Overview
+The system SHALL provide authorized admins and instructors with an MVP-limited overview of content health for published Academy content.
+
+#### Scenario: Overview shows content health
+GIVEN an authorized admin or instructor opens content health
+WHEN the overview renders
+THEN the system displays health summaries for tracks, courses, modules, lessons, focused coding challenges, and Code Prompts
+AND includes published content identity and version context where available.
+
+#### Scenario: Overview excludes draft content by default
+GIVEN content exists only as draft, in review, archived, or unpublished
+WHEN the health overview renders for normal operational review
+THEN the system excludes that content from default health summaries
+AND allows draft or unpublished context only through explicitly authorized admin workflows when product policy permits.
+
+#### Scenario: Mission terminology is used carefully
+GIVEN content health is displayed
+WHEN Academy theming is applied
+THEN the system may frame content issues as signals, incidents, or field reports
+AND keeps operational metrics clear and unambiguous.
+
+### Requirement: Health Signals
+The system SHALL summarize learner outcome signals that indicate content may need review.
+
+#### Scenario: Stuck learner signal
+GIVEN learners spend excessive time, repeat attempts, abandon progress, or repeatedly request help on a content item
+WHEN content health calculates stuck signals
+THEN the system identifies the content item and signal category
+AND distinguishes stuck signals from accepted completions.
+
+#### Scenario: Focused challenge failure signal
+GIVEN learners run focused challenge tests
+WHEN test outcomes are summarized
+THEN the system reports repeated failing tests, timeout or resource-limit results, sandbox infrastructure errors, reset frequency, and completion outcomes where available.
+
+#### Scenario: Code Prompt Delivery signal
+GIVEN learners submit Code Prompt Deliveries
+WHEN Delivery outcomes are summarized
+THEN the system reports accepted, needs-revision, failed, evaluation-error, and pending outcomes
+AND reports revision loop counts where available.
+
+#### Scenario: Drop-off signal
+GIVEN learners start but do not complete a lesson, challenge, Code Prompt, or Delivery
+WHEN content health summarizes progress
+THEN the system identifies drop-off points by content identity and version
+AND avoids treating incomplete in-progress work as failure before the configured threshold is reached.
+
+### Requirement: Content Detail Drill-Down
+The system SHALL allow authorized admins and instructors to inspect content-level health detail without owning the learner workflow.
+
+#### Scenario: Lesson detail
+GIVEN an authorized admin or instructor opens health detail for a lesson
+WHEN lesson health renders
+THEN the system displays starts, completions, drop-offs, stuck signals, related focused challenge outcomes, and active published version context.
+
+#### Scenario: Focused challenge detail
+GIVEN an authorized admin or instructor opens health detail for a focused challenge
+WHEN challenge health renders
+THEN the system displays test pass rates, repeated failing acceptance items, reset frequency, timeout or sandbox error frequency, completion rate, and related content version context.
+
+#### Scenario: Code Prompt detail
+GIVEN an authorized admin or instructor opens health detail for a Code Prompt
+WHEN prompt health renders
+THEN the system displays prompt starts, workspace resumes, Delivery submissions, evaluation outcomes, revision loops, accepted Delivery rate, and active published definition version.
+
+#### Scenario: Detail links to content management
+GIVEN an admin has content authoring permission
+WHEN the admin views a content health detail
+THEN the system provides a path to the corresponding content management record or version
+AND content management remains responsible for edits, validation, preview, and publishing.
+
+### Requirement: Version-Aware Health
+The system SHALL preserve enough content version context to compare health signals before and after publication changes.
+
+#### Scenario: Current version metrics
+GIVEN a content item has a current published version
+WHEN content health renders current metrics
+THEN the system attributes eligible learner outcome signals to that published version where the source signal includes version context.
+
+#### Scenario: Previous version comparison
+GIVEN a content item has previous published versions with outcome signals
+WHEN an authorized admin views version comparison
+THEN the system can show current versus previous version health summaries
+AND identifies when sample size or missing data limits the comparison.
+
+#### Scenario: Rollback context
+GIVEN content was rolled back in admin content management
+WHEN content health renders the affected content
+THEN the system preserves the health history of both the rolled-back-from version and the restored active version
+AND does not rewrite historical outcomes.
+
+### Requirement: Privacy-Aware Health Access
+The system SHALL protect learner privacy when content health uses learner outcome signals.
+
+#### Scenario: Aggregate default
+GIVEN an authorized admin or instructor opens content health
+WHEN health summaries render
+THEN the system defaults to aggregate metrics and signal counts
+AND does not expose learner names, private profile details, billing data, or unrelated account data.
+
+#### Scenario: Learner-level support view
+GIVEN an authorized instructor or support admin has permission to inspect learner-level content support details
+WHEN the learner-level support view is opened
+THEN the system exposes only the learner identity, content identity, attempt status, timestamps, and outcome details needed for support
+AND does not expose unrelated learner data.
+
+#### Scenario: Low sample warning
+GIVEN a content health metric is based on too few learners or incomplete source data
+WHEN the metric is displayed
+THEN the system marks the metric as low-sample, incomplete, or unavailable
+AND avoids presenting it as a reliable content quality conclusion.
+
+### Requirement: Content Health Request States
+The system SHALL handle loading, partial data, missing signals, and failures in content health views.
+
+#### Scenario: Health loading
+GIVEN content health data has not loaded
+WHEN an authorized user opens the health dashboard
+THEN the system displays a loading state
+AND does not show stale health data from another context.
+
+#### Scenario: Partial signal data
+GIVEN some health signal sources are unavailable
+WHEN content health renders
+THEN the system displays available summaries
+AND identifies unavailable or stale signal groups separately.
+
+#### Scenario: Health load failure
+GIVEN content health data cannot be retrieved
+WHEN the dashboard renders
+THEN the system displays a recoverable error
+AND provides a retry path.
+
+### Requirement: Content Health Responsibility Boundary
+The content health dashboard capability SHALL own health signal presentation, summaries, drill-downs, version-aware health context, and privacy-aware health access while consuming source facts from their owning capabilities.
+
+#### Scenario: Lesson challenge provides source facts
+GIVEN focused challenge attempts, test runs, reset events, sandbox failures, or completion outcomes exist
+WHEN content health summarizes those signals
+THEN lesson challenge remains authoritative for the source facts
+AND content health owns aggregation and presentation.
+
+#### Scenario: Code Prompts provide source facts
+GIVEN prompt attempts, Deliveries, evaluations, review reports, revisions, or accepted evidence exist
+WHEN content health summarizes those signals
+THEN Code Prompts and Deliveries remains authoritative for the source facts
+AND content health owns aggregation and presentation.
+
+#### Scenario: Admin content management provides content context
+GIVEN content identity, lifecycle state, published version, rollback history, or authoring metadata is needed for health analysis
+WHEN content health renders content context
+THEN admin content management remains authoritative for content source and version context
+AND content health owns health interpretation and presentation.
+
+#### Scenario: Learner dashboard boundary
+GIVEN learner-facing dashboard data is rendered
+WHEN content health data exists
+THEN the learner dashboard does not expose admin content health views
+AND content health remains an admin/instructor operational capability.

--- a/openspec/changes/define-academy-content-health-dashboard/specs/academy-dashboard/spec.md
+++ b/openspec/changes/define-academy-content-health-dashboard/specs/academy-dashboard/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Dashboard Content Health Boundary
+The learner dashboard capability SHALL NOT expose admin content health views or become responsible for content health summaries.
+
+#### Scenario: Learner dashboard excludes admin health
+GIVEN a learner opens the authenticated dashboard
+WHEN content health signals exist for the learner's path, lesson, challenge, or Code Prompt
+THEN the learner dashboard does not display admin content health metrics
+AND continues to show learner-facing progress, resume prompts, telemetry, and mission-log previews.
+
+#### Scenario: Admin health remains separate
+GIVEN an authorized admin or instructor needs content health information
+WHEN the user opens an admin operational surface
+THEN academy-content-health-dashboard owns the content health presentation
+AND academy-dashboard remains responsible for learner dashboard presentation.

--- a/openspec/changes/define-academy-content-health-dashboard/specs/academy-lesson-challenge/spec.md
+++ b/openspec/changes/define-academy-content-health-dashboard/specs/academy-lesson-challenge/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Lesson Challenge Health Signal Boundary
+The lesson challenge capability SHALL expose focused challenge attempt, test, reset, sandbox, and completion source facts for content health while not owning health aggregation or presentation.
+
+#### Scenario: Challenge outcomes available for health
+GIVEN learners run focused challenge tests
+WHEN content health requests challenge source facts
+THEN lesson challenge can provide attempt identity, content identity, content version when available, test outcomes, reset events, sandbox failures, completion status, and timestamps within authorized scope.
+
+#### Scenario: Health aggregation delegated
+GIVEN challenge outcome source facts exist
+WHEN repeated failures, stuck signals, or completion summaries are displayed
+THEN content health owns aggregation and presentation
+AND lesson challenge remains authoritative for individual attempt and test execution facts.
+
+#### Scenario: Learner workflow unaffected by health
+GIVEN content health processing is delayed or unavailable
+WHEN a learner runs tests or completes a focused challenge
+THEN lesson challenge preserves the learner workflow
+AND does not require the health dashboard to be available for challenge execution.

--- a/openspec/changes/define-academy-content-health-dashboard/specs/academy-mvp-scope/spec.md
+++ b/openspec/changes/define-academy-content-health-dashboard/specs/academy-mvp-scope/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: MVP Content Health Operations Boundary
+The MVP scope SHALL treat content health as limited operational scope for improving the first shippable learner path.
+
+#### Scenario: Content health remains MVP-limited
+GIVEN MVP implementation planning begins
+WHEN content health is planned
+THEN content health includes aggregate stuck signals, failed challenge signals, Delivery outcome summaries, revision loops, drop-off points, and content version context
+AND excludes broad BI, cohort analytics, predictive recommendations, alerts, exports, and automated content edits unless accepted by a later proposal.
+
+#### Scenario: Content health supports content iteration
+GIVEN admins or instructors review the first shippable path
+WHEN content health identifies weak lessons, challenges, or Code Prompts
+THEN the information supports content review and iteration
+AND content revisions still flow through admin content management.
+
+#### Scenario: AI mentor guardrails remain separate
+GIVEN help or mentor behavior contributes learner signals
+WHEN AI mentor behavior is planned
+THEN AI mentor guardrails remain a separate proposal
+AND content health may later consume mentor usage signals only after those guardrails are accepted.

--- a/openspec/changes/define-academy-content-health-dashboard/specs/academy-privacy-controls/spec.md
+++ b/openspec/changes/define-academy-content-health-dashboard/specs/academy-privacy-controls/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Content Health Privacy Boundary
+The privacy controls capability SHALL define privacy expectations for learner data used in content health views without owning content health presentation.
+
+#### Scenario: Health uses minimized learner data
+GIVEN learner outcome signals are used for content health
+WHEN content health metrics are generated or displayed
+THEN the system minimizes learner-identifying data according to privacy policy
+AND privacy controls remain authoritative for data export, erasure, consent, and privacy request behavior.
+
+#### Scenario: Erasure affects health data
+GIVEN a learner's personal data is erased according to policy
+WHEN content health uses historical outcome signals
+THEN the system removes or anonymizes learner-identifying data according to the erasure policy
+AND may retain aggregate non-identifying content health statistics when policy permits.
+
+#### Scenario: Export includes applicable health records
+GIVEN a learner requests a data export
+WHEN exportable learner records include content health source facts tied to that learner
+THEN the export includes those records according to privacy policy
+AND does not include aggregate metrics about other learners.

--- a/openspec/changes/define-academy-content-health-dashboard/tasks.md
+++ b/openspec/changes/define-academy-content-health-dashboard/tasks.md
@@ -1,0 +1,27 @@
+## 1. Proposal Review
+
+- [ ] 1.1 Review `academy-mvp-scope`, `academy-admin-content-management`, `academy-lesson-challenge`, `academy-code-prompts-deliveries`, `academy-dashboard`, and `academy-privacy-controls` for health signal and privacy boundaries.
+- [ ] 1.2 Confirm content health is the next proposal candidate after admin content management.
+- [ ] 1.3 Confirm content health remains MVP-limited and does not absorb broad analytics, adaptive recommendations, alerting, or AI mentor guardrails.
+
+## 2. Spec Application
+
+- [ ] 2.1 Add the accepted `academy-content-health-dashboard` capability to baseline specs.
+- [ ] 2.2 Update `academy-admin-content-management` with content identity/version context boundaries.
+- [ ] 2.3 Update `academy-lesson-challenge` with health source-fact boundaries.
+- [ ] 2.4 Update `academy-code-prompts-deliveries` with prompt and Delivery health source-fact boundaries.
+- [ ] 2.5 Update `academy-dashboard` with learner-dashboard separation from admin content health.
+- [ ] 2.6 Update `academy-privacy-controls` with content health privacy boundaries.
+- [ ] 2.7 Update `academy-mvp-scope` with MVP-limited content health boundaries.
+
+## 3. Follow-Up Planning
+
+- [ ] 3.1 Update follow-up proposal roadmap if needed after content health is accepted.
+- [ ] 3.2 Identify whether AI mentor guardrails or implementation scaffolding should come next.
+- [ ] 3.3 Confirm no application implementation code is included in this capability-definition change.
+
+## 4. Validation
+
+- [ ] 4.1 Run `openspec validate define-academy-content-health-dashboard --strict`.
+- [ ] 4.2 Run `openspec validate --all --strict`.
+- [ ] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.


### PR DESCRIPTION
## Summary

- Adds the OpenSpec proposal `define-academy-content-health-dashboard`.
- Introduces the new `academy-content-health-dashboard` capability.
- Defines MVP-limited content health overview, stuck signals, challenge failures, Code Prompt Delivery outcomes, drill-downs, version-aware health context, request states, and privacy-aware access.
- Adds boundary deltas for admin content management, lesson challenge, Code Prompts and Deliveries, learner dashboard, privacy controls, and MVP scope.

## Notes

This is planning/specification only. It does not implement frontend, backend, storage, API, event, analytics, or infrastructure code.

## Verification

- `openspec validate define-academy-content-health-dashboard --strict`
- `openspec validate --all --strict`
- `git diff --check HEAD~1 HEAD`