### PR TITLE
docs: apply academy content health dashboard spec

### DIFF
--- a/docs/openspec-follow-up-proposals.md
+++ b/docs/openspec-follow-up-proposals.md
@@ -15,11 +15,11 @@ and `academy-mvp-scope`.
    - Establish the minimum content operations needed to run the first shippable path.
    - Depends on `academy-mvp-scope`.
 
-3. `define-academy-content-health-dashboard` (next)
+3. `define-academy-content-health-dashboard` (accepted)
    - Define instructor/admin visibility into stuck learners, failed attempts, prompt delivery outcomes, and content quality signals.
    - Depends on `academy-mvp-scope`.
 
-4. `define-academy-ai-mentor-guardrails`
+4. `define-academy-ai-mentor-guardrails` (next)
    - Define no-direct-answer, hint-ladder, lesson/prompt scope, explain-don't-solve, and authored-hint fallback behavior.
    - Depends on `academy-mvp-scope`.
 
@@ -57,6 +57,6 @@ and `academy-mvp-scope`.
 
 ## First Implementation Recommendation
 
-Start with `define-academy-content-health-dashboard`.
+Start with `define-academy-ai-mentor-guardrails`.
 
-Reason: `academy-code-prompts-deliveries` defines the learner prompt and Delivery loop, and `academy-admin-content-management` defines how that content is authored and published. Content health should come next so failed attempts, stuck signals, and Delivery outcomes are specified before implementation scaffolding hardens the data shape.
+Reason: `academy-code-prompts-deliveries`, `academy-admin-content-management`, and `academy-content-health-dashboard` now define the learner prompt loop, content operations, and operational health visibility. AI mentor guardrails should come next so help behavior is bounded before live AI or authored-hint implementation.

--- a/openspec/changes/define-academy-content-health-dashboard/tasks.md
+++ b/openspec/changes/define-academy-content-health-dashboard/tasks.md
@@ -1,27 +1,27 @@
 ## 1. Proposal Review
 
-- [ ] 1.1 Review `academy-mvp-scope`, `academy-admin-content-management`, `academy-lesson-challenge`, `academy-code-prompts-deliveries`, `academy-dashboard`, and `academy-privacy-controls` for health signal and privacy boundaries.
-- [ ] 1.2 Confirm content health is the next proposal candidate after admin content management.
-- [ ] 1.3 Confirm content health remains MVP-limited and does not absorb broad analytics, adaptive recommendations, alerting, or AI mentor guardrails.
+- [x] 1.1 Review `academy-mvp-scope`, `academy-admin-content-management`, `academy-lesson-challenge`, `academy-code-prompts-deliveries`, `academy-dashboard`, and `academy-privacy-controls` for health signal and privacy boundaries.
+- [x] 1.2 Confirm content health is the next proposal candidate after admin content management.
+- [x] 1.3 Confirm content health remains MVP-limited and does not absorb broad analytics, adaptive recommendations, alerting, or AI mentor guardrails.
 
 ## 2. Spec Application
 
-- [ ] 2.1 Add the accepted `academy-content-health-dashboard` capability to baseline specs.
-- [ ] 2.2 Update `academy-admin-content-management` with content identity/version context boundaries.
-- [ ] 2.3 Update `academy-lesson-challenge` with health source-fact boundaries.
-- [ ] 2.4 Update `academy-code-prompts-deliveries` with prompt and Delivery health source-fact boundaries.
-- [ ] 2.5 Update `academy-dashboard` with learner-dashboard separation from admin content health.
-- [ ] 2.6 Update `academy-privacy-controls` with content health privacy boundaries.
-- [ ] 2.7 Update `academy-mvp-scope` with MVP-limited content health boundaries.
+- [x] 2.1 Add the accepted `academy-content-health-dashboard` capability to baseline specs.
+- [x] 2.2 Update `academy-admin-content-management` with content identity/version context boundaries.
+- [x] 2.3 Update `academy-lesson-challenge` with health source-fact boundaries.
+- [x] 2.4 Update `academy-code-prompts-deliveries` with prompt and Delivery health source-fact boundaries.
+- [x] 2.5 Update `academy-dashboard` with learner-dashboard separation from admin content health.
+- [x] 2.6 Update `academy-privacy-controls` with content health privacy boundaries.
+- [x] 2.7 Update `academy-mvp-scope` with MVP-limited content health boundaries.
 
 ## 3. Follow-Up Planning
 
-- [ ] 3.1 Update follow-up proposal roadmap if needed after content health is accepted.
-- [ ] 3.2 Identify whether AI mentor guardrails or implementation scaffolding should come next.
-- [ ] 3.3 Confirm no application implementation code is included in this capability-definition change.
+- [x] 3.1 Update follow-up proposal roadmap if needed after content health is accepted.
+- [x] 3.2 Identify whether AI mentor guardrails or implementation scaffolding should come next.
+- [x] 3.3 Confirm no application implementation code is included in this capability-definition change.
 
 ## 4. Validation
 
-- [ ] 4.1 Run `openspec validate define-academy-content-health-dashboard --strict`.
-- [ ] 4.2 Run `openspec validate --all --strict`.
-- [ ] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.
+- [x] 4.1 Run `openspec validate define-academy-content-health-dashboard --strict`.
+- [x] 4.2 Run `openspec validate --all --strict`.
+- [x] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.

--- a/openspec/specs/academy-admin-content-management/spec.md
+++ b/openspec/specs/academy-admin-content-management/spec.md
@@ -198,3 +198,24 @@ GIVEN a user performs content management actions
 WHEN permissions are checked
 THEN authentication and authorization systems provide identity and permission decisions
 AND admin content management applies those decisions to content actions.
+
+### Requirement: Content Health Context Boundary
+The admin content management capability SHALL provide content identity, lifecycle, and version context for content health while not owning health signal presentation or analytics.
+
+#### Scenario: Content identity provided to health
+GIVEN published content exists
+WHEN content health summarizes learner outcome signals
+THEN admin content management provides the content identity and published version context needed to attribute signals
+AND content health owns health summaries and drill-down presentation.
+
+#### Scenario: Health links back to authoring
+GIVEN an admin reviews a content health detail
+WHEN the admin opens the associated content record
+THEN admin content management owns the authoring, validation, preview, and publish workflow for any changes
+AND content health remains responsible only for health signal interpretation.
+
+#### Scenario: Health does not mutate content
+GIVEN content health identifies a weak lesson, challenge, or Code Prompt
+WHEN an admin reviews the signal
+THEN content health does not directly mutate content state
+AND any content revision, unpublish, rollback, or archive action belongs to admin content management.

--- a/openspec/specs/academy-code-prompts-deliveries/spec.md
+++ b/openspec/specs/academy-code-prompts-deliveries/spec.md
@@ -258,3 +258,23 @@ GIVEN an admin edits mission brief, objective, constraints, starting point, Deli
 WHEN the edit is saved, validated, previewed, or published
 THEN academy-admin-content-management owns that prompt-definition operation
 AND Code Prompts and Deliveries consumes the resulting published definition.
+
+### Requirement: Code Prompt Health Signal Boundary
+The Code Prompts and Deliveries capability SHALL expose prompt attempt, Delivery, evaluation, review, revision, and accepted-evidence source facts for content health while not owning health aggregation or presentation.
+
+#### Scenario: Prompt outcomes available for health
+GIVEN learners work on Code Prompts
+WHEN content health requests prompt source facts
+THEN Code Prompts and Deliveries can provide prompt identity, published definition version when available, attempt status, workspace lifecycle events, Delivery status, evaluation outcomes, review report status, revision counts, accepted evidence status, and timestamps within authorized scope.
+
+#### Scenario: Health aggregation delegated
+GIVEN prompt and Delivery source facts exist
+WHEN accepted rates, needs-revision rates, failed Delivery rates, evaluation-error rates, or revision loops are displayed
+THEN content health owns aggregation and presentation
+AND Code Prompts and Deliveries remains authoritative for individual prompt, Delivery, evaluation, review, and revision facts.
+
+#### Scenario: Evaluation workflow unaffected by health
+GIVEN content health processing is delayed or unavailable
+WHEN a learner submits a Delivery or receives an evaluation result
+THEN Code Prompts and Deliveries preserves the learner workflow
+AND does not require the health dashboard to be available for prompt evaluation or review.

--- a/openspec/specs/academy-content-health-dashboard/spec.md
+++ b/openspec/specs/academy-content-health-dashboard/spec.md
@@ -1,0 +1,169 @@
+# Academy Content Health Dashboard Specification
+
+## Purpose
+
+Define the Presstronic Academy content health dashboard capability.
+
+This specification captures MVP-limited admin and instructor visibility into content health using stuck learner signals, repeated focused challenge failures, Code Prompt Delivery outcomes, revision loops, drop-off points, content version context, request states, and privacy-aware access. It does not specify final database schemas, event transport, metrics warehouses, charting libraries, alerts, exports, automated recommendations, AI-generated content edits, or B2B assessment analytics.
+
+## Requirements
+
+### Requirement: Content Health Overview
+The system SHALL provide authorized admins and instructors with an MVP-limited overview of content health for published Academy content.
+
+#### Scenario: Overview shows content health
+GIVEN an authorized admin or instructor opens content health
+WHEN the overview renders
+THEN the system displays health summaries for tracks, courses, modules, lessons, focused coding challenges, and Code Prompts
+AND includes published content identity and version context where available.
+
+#### Scenario: Overview excludes draft content by default
+GIVEN content exists only as draft, in review, archived, or unpublished
+WHEN the health overview renders for normal operational review
+THEN the system excludes that content from default health summaries
+AND allows draft or unpublished context only through explicitly authorized admin workflows when product policy permits.
+
+#### Scenario: Mission terminology is used carefully
+GIVEN content health is displayed
+WHEN Academy theming is applied
+THEN the system may frame content issues as signals, incidents, or field reports
+AND keeps operational metrics clear and unambiguous.
+
+### Requirement: Health Signals
+The system SHALL summarize learner outcome signals that indicate content may need review.
+
+#### Scenario: Stuck learner signal
+GIVEN learners spend excessive time, repeat attempts, abandon progress, or repeatedly request help on a content item
+WHEN content health calculates stuck signals
+THEN the system identifies the content item and signal category
+AND distinguishes stuck signals from accepted completions.
+
+#### Scenario: Focused challenge failure signal
+GIVEN learners run focused challenge tests
+WHEN test outcomes are summarized
+THEN the system reports repeated failing tests, timeout or resource-limit results, sandbox infrastructure errors, reset frequency, and completion outcomes where available.
+
+#### Scenario: Code Prompt Delivery signal
+GIVEN learners submit Code Prompt Deliveries
+WHEN Delivery outcomes are summarized
+THEN the system reports accepted, needs-revision, failed, evaluation-error, and pending outcomes
+AND reports revision loop counts where available.
+
+#### Scenario: Drop-off signal
+GIVEN learners start but do not complete a lesson, challenge, Code Prompt, or Delivery
+WHEN content health summarizes progress
+THEN the system identifies drop-off points by content identity and version
+AND avoids treating incomplete in-progress work as failure before the configured threshold is reached.
+
+### Requirement: Content Detail Drill-Down
+The system SHALL allow authorized admins and instructors to inspect content-level health detail without owning the learner workflow.
+
+#### Scenario: Lesson detail
+GIVEN an authorized admin or instructor opens health detail for a lesson
+WHEN lesson health renders
+THEN the system displays starts, completions, drop-offs, stuck signals, related focused challenge outcomes, and active published version context.
+
+#### Scenario: Focused challenge detail
+GIVEN an authorized admin or instructor opens health detail for a focused challenge
+WHEN challenge health renders
+THEN the system displays test pass rates, repeated failing acceptance items, reset frequency, timeout or sandbox error frequency, completion rate, and related content version context.
+
+#### Scenario: Code Prompt detail
+GIVEN an authorized admin or instructor opens health detail for a Code Prompt
+WHEN prompt health renders
+THEN the system displays prompt starts, workspace resumes, Delivery submissions, evaluation outcomes, revision loops, accepted Delivery rate, and active published definition version.
+
+#### Scenario: Detail links to content management
+GIVEN an admin has content authoring permission
+WHEN the admin views a content health detail
+THEN the system provides a path to the corresponding content management record or version
+AND content management remains responsible for edits, validation, preview, and publishing.
+
+### Requirement: Version-Aware Health
+The system SHALL preserve enough content version context to compare health signals before and after publication changes.
+
+#### Scenario: Current version metrics
+GIVEN a content item has a current published version
+WHEN content health renders current metrics
+THEN the system attributes eligible learner outcome signals to that published version where the source signal includes version context.
+
+#### Scenario: Previous version comparison
+GIVEN a content item has previous published versions with outcome signals
+WHEN an authorized admin views version comparison
+THEN the system can show current versus previous version health summaries
+AND identifies when sample size or missing data limits the comparison.
+
+#### Scenario: Rollback context
+GIVEN content was rolled back in admin content management
+WHEN content health renders the affected content
+THEN the system preserves the health history of both the rolled-back-from version and the restored active version
+AND does not rewrite historical outcomes.
+
+### Requirement: Privacy-Aware Health Access
+The system SHALL protect learner privacy when content health uses learner outcome signals.
+
+#### Scenario: Aggregate default
+GIVEN an authorized admin or instructor opens content health
+WHEN health summaries render
+THEN the system defaults to aggregate metrics and signal counts
+AND does not expose learner names, private profile details, billing data, or unrelated account data.
+
+#### Scenario: Learner-level support view
+GIVEN an authorized instructor or support admin has permission to inspect learner-level content support details
+WHEN the learner-level support view is opened
+THEN the system exposes only the learner identity, content identity, attempt status, timestamps, and outcome details needed for support
+AND does not expose unrelated learner data.
+
+#### Scenario: Low sample warning
+GIVEN a content health metric is based on too few learners or incomplete source data
+WHEN the metric is displayed
+THEN the system marks the metric as low-sample, incomplete, or unavailable
+AND avoids presenting it as a reliable content quality conclusion.
+
+### Requirement: Content Health Request States
+The system SHALL handle loading, partial data, missing signals, and failures in content health views.
+
+#### Scenario: Health loading
+GIVEN content health data has not loaded
+WHEN an authorized user opens the health dashboard
+THEN the system displays a loading state
+AND does not show stale health data from another context.
+
+#### Scenario: Partial signal data
+GIVEN some health signal sources are unavailable
+WHEN content health renders
+THEN the system displays available summaries
+AND identifies unavailable or stale signal groups separately.
+
+#### Scenario: Health load failure
+GIVEN content health data cannot be retrieved
+WHEN the dashboard renders
+THEN the system displays a recoverable error
+AND provides a retry path.
+
+### Requirement: Content Health Responsibility Boundary
+The content health dashboard capability SHALL own health signal presentation, summaries, drill-downs, version-aware health context, and privacy-aware health access while consuming source facts from their owning capabilities.
+
+#### Scenario: Lesson challenge provides source facts
+GIVEN focused challenge attempts, test runs, reset events, sandbox failures, or completion outcomes exist
+WHEN content health summarizes those signals
+THEN lesson challenge remains authoritative for the source facts
+AND content health owns aggregation and presentation.
+
+#### Scenario: Code Prompts provide source facts
+GIVEN prompt attempts, Deliveries, evaluations, review reports, revisions, or accepted evidence exist
+WHEN content health summarizes those signals
+THEN Code Prompts and Deliveries remains authoritative for the source facts
+AND content health owns aggregation and presentation.
+
+#### Scenario: Admin content management provides content context
+GIVEN content identity, lifecycle state, published version, rollback history, or authoring metadata is needed for health analysis
+WHEN content health renders content context
+THEN admin content management remains authoritative for content source and version context
+AND content health owns health interpretation and presentation.
+
+#### Scenario: Learner dashboard boundary
+GIVEN learner-facing dashboard data is rendered
+WHEN content health data exists
+THEN the learner dashboard does not expose admin content health views
+AND content health remains an admin/instructor operational capability.

--- a/openspec/specs/academy-dashboard/spec.md
+++ b/openspec/specs/academy-dashboard/spec.md
@@ -203,3 +203,18 @@ The dashboard capability SHALL own dashboard presentation, resume prompts, summa
 - **WHEN** the learner interacts with a transmission
 - **THEN** dashboard routes to the relevant destination
 - **AND** academy-mission-log owns read state, grouping, counts, and log persistence.
+
+### Requirement: Dashboard Content Health Boundary
+The learner dashboard capability SHALL NOT expose admin content health views or become responsible for content health summaries.
+
+#### Scenario: Learner dashboard excludes admin health
+GIVEN a learner opens the authenticated dashboard
+WHEN content health signals exist for the learner's path, lesson, challenge, or Code Prompt
+THEN the learner dashboard does not display admin content health metrics
+AND continues to show learner-facing progress, resume prompts, telemetry, and mission-log previews.
+
+#### Scenario: Admin health remains separate
+GIVEN an authorized admin or instructor needs content health information
+WHEN the user opens an admin operational surface
+THEN academy-content-health-dashboard owns the content health presentation
+AND academy-dashboard remains responsible for learner dashboard presentation.

--- a/openspec/specs/academy-lesson-challenge/spec.md
+++ b/openspec/specs/academy-lesson-challenge/spec.md
@@ -366,3 +366,23 @@ GIVEN an admin edits lesson body, starter code, tests, acceptance criteria, or c
 WHEN the edit is saved, validated, previewed, or published
 THEN academy-admin-content-management owns that content operation
 AND lesson challenge consumes the resulting published content.
+
+### Requirement: Lesson Challenge Health Signal Boundary
+The lesson challenge capability SHALL expose focused challenge attempt, test, reset, sandbox, and completion source facts for content health while not owning health aggregation or presentation.
+
+#### Scenario: Challenge outcomes available for health
+GIVEN learners run focused challenge tests
+WHEN content health requests challenge source facts
+THEN lesson challenge can provide attempt identity, content identity, content version when available, test outcomes, reset events, sandbox failures, completion status, and timestamps within authorized scope.
+
+#### Scenario: Health aggregation delegated
+GIVEN challenge outcome source facts exist
+WHEN repeated failures, stuck signals, or completion summaries are displayed
+THEN content health owns aggregation and presentation
+AND lesson challenge remains authoritative for individual attempt and test execution facts.
+
+#### Scenario: Learner workflow unaffected by health
+GIVEN content health processing is delayed or unavailable
+WHEN a learner runs tests or completes a focused challenge
+THEN lesson challenge preserves the learner workflow
+AND does not require the health dashboard to be available for challenge execution.

--- a/openspec/specs/academy-mvp-scope/spec.md
+++ b/openspec/specs/academy-mvp-scope/spec.md
@@ -177,3 +177,24 @@ GIVEN learner outcome signals need to be analyzed against content
 WHEN health dashboards are planned
 THEN content health dashboard remains a separate capability
 AND admin content management provides content identity and version context.
+
+### Requirement: MVP Content Health Operations Boundary
+The MVP scope SHALL treat content health as limited operational scope for improving the first shippable learner path.
+
+#### Scenario: Content health remains MVP-limited
+GIVEN MVP implementation planning begins
+WHEN content health is planned
+THEN content health includes aggregate stuck signals, failed challenge signals, Delivery outcome summaries, revision loops, drop-off points, and content version context
+AND excludes broad BI, cohort analytics, predictive recommendations, alerts, exports, and automated content edits unless accepted by a later proposal.
+
+#### Scenario: Content health supports content iteration
+GIVEN admins or instructors review the first shippable path
+WHEN content health identifies weak lessons, challenges, or Code Prompts
+THEN the information supports content review and iteration
+AND content revisions still flow through admin content management.
+
+#### Scenario: AI mentor guardrails remain separate
+GIVEN help or mentor behavior contributes learner signals
+WHEN AI mentor behavior is planned
+THEN AI mentor guardrails remain a separate proposal
+AND content health may later consume mentor usage signals only after those guardrails are accepted.

--- a/openspec/specs/academy-privacy-controls/spec.md
+++ b/openspec/specs/academy-privacy-controls/spec.md
@@ -172,3 +172,24 @@ The privacy-controls capability SHALL be the authoritative owner for data export
 - **GIVEN** a surface describes a privacy action in its own words
 - **WHEN** the privacy flow executes
 - **THEN** the privacy-controls capability remains the source of truth for policy, consent, erasure, export, and accessibility requirements.
+
+### Requirement: Content Health Privacy Boundary
+The privacy controls capability SHALL define privacy expectations for learner data used in content health views without owning content health presentation.
+
+#### Scenario: Health uses minimized learner data
+GIVEN learner outcome signals are used for content health
+WHEN content health metrics are generated or displayed
+THEN the system minimizes learner-identifying data according to privacy policy
+AND privacy controls remain authoritative for data export, erasure, consent, and privacy request behavior.
+
+#### Scenario: Erasure affects health data
+GIVEN a learner's personal data is erased according to policy
+WHEN content health uses historical outcome signals
+THEN the system removes or anonymizes learner-identifying data according to the erasure policy
+AND may retain aggregate non-identifying content health statistics when policy permits.
+
+#### Scenario: Export includes applicable health records
+GIVEN a learner requests a data export
+WHEN exportable learner records include content health source facts tied to that learner
+THEN the export includes those records according to privacy policy
+AND does not include aggregate metrics about other learners.


### PR DESCRIPTION
## Summary

- Applies the accepted `define-academy-content-health-dashboard` change into baseline OpenSpec specs.
- Adds the new baseline `academy-content-health-dashboard` capability.
- Adds health boundary requirements to admin content management, lesson challenge, Code Prompts and Deliveries, learner dashboard, privacy controls, and MVP scope.
- Marks the change tasks complete and updates the follow-up roadmap to make AI mentor guardrails the next proposal candidate.

## Notes

This is specification/documentation only. It does not include frontend, backend, storage, API, event, analytics, or infrastructure implementation.

## Verification

- `openspec validate define-academy-content-health-dashboard --strict`
- `openspec validate --all --strict`
- `git diff --check`