### PR TITLE
docs: propose academy ai mentor guardrails

### DIFF
--- a/openspec/changes/define-academy-ai-mentor-guardrails/.openspec.yaml
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/define-academy-ai-mentor-guardrails/README.md
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/README.md
@@ -1,0 +1,3 @@
+# define-academy-ai-mentor-guardrails
+
+Define MVP-limited AI mentor guardrails for no-direct-answer coaching, hint ladders, scoped context, authored-hint fallback, privacy boundaries, request states, and ownership boundaries across lessons and Code Prompts.

--- a/openspec/changes/define-academy-ai-mentor-guardrails/design.md
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The lesson challenge baseline already includes an AI mentor panel with context chips, sample exchange, request state, and a privacy disclosure. The MVP scope says mentor behavior should use no-direct-answer, hint-ladder, lesson-scope, and explain-don't-solve guardrails. Code Prompts and Deliveries define realistic project-style submissions, where learners will likely need support without the mentor simply solving the project.
+
+This proposal makes mentor behavior an explicit shared capability so lesson challenges and Code Prompts can consume the same coaching policy. It also lets MVP ship with authored hints first if live AI slows the launch.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the shared mentor guardrail capability.
+- Preserve learning by requiring no-direct-answer and explain-don't-solve behavior.
+- Define progressive hint ladders, scoped context, refusal/redirection, and authored-hint fallback.
+- Protect hidden tests, hidden evaluation checks, rubrics, and solution material.
+- Define privacy boundaries for mentor context, logs, retention, export, and erasure.
+- Define how aggregate mentor usage can later feed content health.
+- Keep Academy mission/CYOA tone present while keeping technical help clear.
+
+**Non-Goals:**
+
+- Do not implement live AI, model/provider selection, prompt templates, moderation tooling, storage schemas, API endpoints, or frontend components.
+- Do not define AI grading or autonomous Delivery acceptance.
+- Do not define advanced adaptive review, mistake memory, or personalized curriculum generation.
+- Do not make mentor guardrails own lesson execution, prompt evaluation, learner progress, or content health dashboards.
+
+## Decisions
+
+### Decision: Mentor guardrails are a shared policy capability
+
+Lesson challenge and Code Prompts need similar help boundaries. A shared capability avoids duplicating policies and makes it easier to keep help behavior consistent.
+
+Alternative considered: leave mentor rules inside lesson challenge only. That would not cover Code Prompts and would likely split policy as soon as prompt mentor help is added.
+
+### Decision: The mentor teaches through hints, not final answers
+
+The mentor should ask diagnostic questions, point to relevant concepts, explain failing signals, and provide incremental hints. It should not provide complete solutions, hidden checks, or finished Deliveries.
+
+Alternative considered: allow full answer generation for convenience. That would make progress and Delivery evidence much less credible.
+
+### Decision: Authored hints are a first-class fallback
+
+MVP should not depend on live AI to provide useful help. Authored hints can satisfy the guardrail contract and provide a launchable fallback when AI is unavailable or intentionally disabled.
+
+Alternative considered: make live AI required for mentor launch. That adds provider, cost, quality, safety, and privacy dependencies before the core learner loop is proven.
+
+### Decision: Mentor context is scoped to the active learning task
+
+The mentor should receive only the current lesson or prompt context, learner work relevant to that task, recent test or evaluation results, and conversation context needed for continuity. It should not receive unrelated profile, billing, private account, or cross-course data by default.
+
+Alternative considered: send broad learner context for personalization. That may help later, but it increases privacy and policy risk before there is a proven need.
+
+## Risks / Trade-offs
+
+- Guardrails can feel restrictive -> Use progressive hints and clear explanations so the mentor remains helpful.
+- Live model behavior may vary -> Treat provider prompts as implementation details and specify observable product behavior here.
+- Authored hints can be shallow -> Let authored hints satisfy MVP fallback, then expand after real learner usage.
+- Hidden checks may leak through explanation -> Explicitly forbid exposing hidden implementation details while still allowing actionable guidance.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Apply the `academy-ai-mentor-guardrails` baseline spec and boundary deltas.
+3. Create follow-up implementation proposals for frontend mentor UI behavior, backend mentor APIs, authored hint storage, and optional live AI integration.
+4. Move roadmap focus to frontend workspace scaffolding after this guardrail change is accepted.
+
+## Open Questions
+
+- Should MVP mentor history be persisted by default or only within the active attempt/session?
+- Should authored hints be authored as part of lesson/prompt content, a separate hint library, or implementation-defined for MVP?
+- What usage limits should apply before billing/access rules are fully implemented?
+- Should Code Prompt mentor help be disabled during final Delivery submission, or only constrained by no-direct-answer guardrails?

--- a/openspec/changes/define-academy-ai-mentor-guardrails/proposal.md
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The MVP includes mentor-style help in lessons and likely needs similar help for Code Prompts. Without explicit guardrails, AI assistance can undercut learning by giving direct answers, leaking hidden checks, expanding outside lesson scope, or sending more learner data than needed.
+
+The Academy should make mentor behavior useful but bounded: hints should teach, preserve learner agency, and keep the mission/CYOA tone without obscuring technical guidance. This proposal defines the mentor guardrail capability before live AI, authored hints, frontend scaffolding, backend contracts, or provider-specific model decisions are implemented.
+
+## What Changes
+
+- Add a new `academy-ai-mentor-guardrails` capability for mentor coaching policy, hint ladders, no-direct-answer behavior, context limits, escalation, request states, and privacy boundaries.
+- Define MVP behavior for lesson challenge mentor support and Code Prompt mentor support.
+- Define authored-hint fallback behavior so MVP can ship mentor guidance without depending on live AI.
+- Define hidden-solution and hidden-check protection for tests, evaluation checks, and prompt rubrics.
+- Define safety behavior for out-of-scope, answer-seeking, policy-sensitive, and unsupported mentor requests.
+- Add boundary deltas so lesson challenge and Code Prompts consume mentor guardrails while retaining ownership of their learner workflows.
+- Add privacy and content health boundaries for mentor context sharing, retention, and aggregate mentor usage signals.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-ai-mentor-guardrails`: Mentor policy and behavior boundaries for no-direct-answer coaching, hint ladders, scoped assistance, context sharing, fallback hints, request states, and signal emission.
+
+### Modified Capabilities
+
+- `academy-lesson-challenge`: Uses mentor guardrails for lesson and focused challenge help while retaining challenge workflow ownership.
+- `academy-code-prompts-deliveries`: Uses mentor guardrails for Code Prompt help while retaining prompt workspace, Delivery, evaluation, review, and revision ownership.
+- `academy-content-health-dashboard`: May consume aggregate mentor usage signals after guardrails are accepted but does not own mentor behavior.
+- `academy-privacy-controls`: Defines privacy expectations for mentor context, logs, retention, export, and erasure.
+- `academy-mvp-scope`: Recognizes AI mentor guardrails as MVP-lite scope and keeps advanced AI review deferred.
+
+## Impact
+
+- Affects future frontend mentor UI, backend mentor APIs, model/provider integration, authored hint content, event logging, and privacy implementation proposals.
+- Keeps the first mentor scope focused on coaching behavior, not autonomous evaluation, code generation, or final-answer delivery.
+- Does not define provider-specific prompts, model selection, token budgets, moderation tooling, database schemas, API endpoints, or live AI implementation.
+- Establishes frontend workspace scaffolding as the next roadmap candidate after this guardrail proposal is accepted.

--- a/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-ai-mentor-guardrails/spec.md
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-ai-mentor-guardrails/spec.md
@@ -1,0 +1,189 @@
+## ADDED Requirements
+
+### Requirement: Mentor Coaching Contract
+The system SHALL provide AI mentor behavior that supports learning without completing the learner's work for them.
+
+#### Scenario: Mentor gives coaching guidance
+GIVEN a learner asks for help in a supported lesson or Code Prompt context
+WHEN mentor guidance is available
+THEN the mentor explains relevant concepts, asks diagnostic questions, points to observed evidence, and suggests next investigation steps
+AND preserves learner responsibility for the final solution or Delivery.
+
+#### Scenario: Mentor refuses direct answer request
+GIVEN a learner asks the mentor for a complete solution, final code, hidden answer, or finished Delivery
+WHEN the mentor responds
+THEN the mentor refuses to provide the direct answer
+AND redirects to a hint, explanation, debugging step, or smaller question the learner can act on.
+
+#### Scenario: Mentor explains without solving
+GIVEN a learner asks why something is failing
+WHEN the mentor has enough task context
+THEN the mentor explains the likely concept or failure mode
+AND does not replace the learner's code, implementation notes, or Delivery evidence with a completed answer.
+
+### Requirement: Hint Ladder
+The system SHALL support progressive hint behavior that increases specificity without jumping directly to a solution.
+
+#### Scenario: First hint is broad
+GIVEN a learner asks for help before receiving prior hints for the same issue
+WHEN the mentor responds
+THEN the mentor starts with a conceptual or diagnostic hint
+AND avoids implementation-level instructions unless the learner context requires basic orientation.
+
+#### Scenario: Later hints become more specific
+GIVEN a learner continues to struggle after earlier hints
+WHEN the mentor responds again for the same issue
+THEN the mentor may provide a more specific hint, targeted example, or debugging checklist
+AND still avoids providing a complete solution.
+
+#### Scenario: Hint ladder uses current signals
+GIVEN the mentor has access to current code, test results, Delivery status, or evaluation feedback
+WHEN the mentor chooses a hint level
+THEN the mentor uses those signals to avoid repeating irrelevant generic advice
+AND keeps the next step tied to the current learner task.
+
+### Requirement: Scope and Context Limits
+The system SHALL limit mentor assistance to the active learning context and disclosed learner work.
+
+#### Scenario: Lesson context
+GIVEN a learner asks for mentor help inside a lesson challenge
+WHEN mentor context is prepared
+THEN the system may include lesson content, challenge instructions, current code, latest test results, acceptance criteria, and relevant conversation history
+AND excludes unrelated profile, billing, private account, and cross-course data by default.
+
+#### Scenario: Code Prompt context
+GIVEN a learner asks for mentor help inside a Code Prompt
+WHEN mentor context is prepared
+THEN the system may include prompt brief, objective, constraints, starting point, Delivery checklist, learner workspace context, evaluation feedback, and relevant conversation history
+AND excludes unrelated learner data by default.
+
+#### Scenario: Out-of-scope request
+GIVEN a learner asks for help unrelated to the active lesson or prompt
+WHEN the mentor responds
+THEN the mentor redirects the learner back to the active task when possible
+AND avoids giving unsupported broad advice that conflicts with the learning objective.
+
+### Requirement: Hidden Material Protection
+The system SHALL prevent mentor behavior from revealing protected answers, hidden checks, rubrics, or evaluation internals.
+
+#### Scenario: Hidden tests are protected
+GIVEN a challenge or Code Prompt uses hidden tests or protected checks
+WHEN the learner asks about hidden test implementation
+THEN the mentor does not reveal hidden test code, exact assertions, or protected fixtures
+AND may explain the visible failure category or concept being assessed.
+
+#### Scenario: Rubric internals are protected
+GIVEN a Code Prompt has internal evaluation guidance or review rubrics
+WHEN the learner asks the mentor for the rubric or scoring shortcut
+THEN the mentor does not reveal protected rubric details
+AND may summarize public evaluation expectations already visible to the learner.
+
+#### Scenario: Solution material is protected
+GIVEN authored solution code, reference implementations, or instructor-only notes exist
+WHEN mentor context is prepared or mentor output is generated
+THEN the system prevents those protected materials from being exposed to the learner.
+
+### Requirement: Authored-Hint Fallback
+The system SHALL support authored hints as a fallback or alternative to live AI mentor responses.
+
+#### Scenario: Authored hint used
+GIVEN a live mentor response is unavailable, disabled, rate-limited, or not approved for the current context
+WHEN the learner requests help
+THEN the system can provide an authored hint that matches the lesson, challenge, prompt, or current failure signal
+AND indicates when only authored guidance is available.
+
+#### Scenario: No matching authored hint
+GIVEN no live mentor response is available
+AND no matching authored hint exists
+WHEN the learner requests help
+THEN the system displays a recoverable unavailable state
+AND suggests reviewing the current brief, tests, constraints, or visible feedback.
+
+#### Scenario: Authored hints follow guardrails
+GIVEN authored hints are configured for a lesson, challenge, or Code Prompt
+WHEN a hint is displayed
+THEN the hint follows no-direct-answer, hint-ladder, scope, and hidden-material protection requirements.
+
+### Requirement: Mentor Request States
+The system SHALL handle mentor availability, pending, cancellation, failure, retry, and usage-limit states.
+
+#### Scenario: Mentor request pending
+GIVEN the learner submits a mentor question
+WHEN a mentor response is being generated or retrieved
+THEN the system displays pending state
+AND prevents duplicate sends for the same prompt.
+
+#### Scenario: Mentor request canceled
+GIVEN a mentor response is pending
+WHEN cancellation is available and the learner cancels
+THEN the system stops or abandons the response where feasible
+AND preserves the learner's prompt text or conversation state.
+
+#### Scenario: Mentor request failure
+GIVEN a mentor request fails
+WHEN the failure is displayed
+THEN the system provides retryable feedback
+AND does not invent mentor guidance or claim the request succeeded.
+
+#### Scenario: Mentor usage limited
+GIVEN mentor usage limits apply
+WHEN the learner reaches a configured limit
+THEN the system explains the limit
+AND may offer authored hints or non-AI guidance when available.
+
+### Requirement: Mentor Privacy and Retention
+The system SHALL disclose mentor context sharing and handle mentor records according to privacy requirements.
+
+#### Scenario: Context disclosure
+GIVEN a learner uses mentor help
+WHEN the mentor entry point or prompt area renders
+THEN the system discloses the task context that may be shared with the mentor
+AND avoids implying unrelated learner data is shared.
+
+#### Scenario: Mentor records retained
+GIVEN mentor conversation records are persisted
+WHEN the records are stored
+THEN the system associates them with the learner, task context, and attempt where applicable
+AND applies retention, export, and erasure behavior defined by privacy controls.
+
+#### Scenario: Sensitive data minimization
+GIVEN a learner enters secrets, credentials, payment data, or unrelated personal data into a mentor prompt
+WHEN mentor processing occurs
+THEN the system minimizes, blocks, redacts, or warns according to product policy where feasible
+AND does not require unrelated sensitive data for mentor help.
+
+### Requirement: Mentor Signal Boundary
+The system SHALL allow mentor usage facts to be consumed by content health only as aggregate or authorized support signals.
+
+#### Scenario: Aggregate mentor usage signal
+GIVEN mentor usage events exist for a lesson, challenge, or Code Prompt
+WHEN content health summarizes help-seeking behavior
+THEN content health may consume aggregate mentor usage counts, repeated-help indicators, and unresolved-help indicators
+AND mentor guardrails remain authoritative for mentor behavior policy.
+
+#### Scenario: Learner-level mentor support signal
+GIVEN an authorized instructor or support admin views learner-level support context
+WHEN mentor usage facts are included
+THEN the system exposes only mentor metadata or conversation details allowed by privacy policy and authorization scope
+AND does not expose unrelated learner data.
+
+### Requirement: Mentor Responsibility Boundary
+The AI mentor guardrails capability SHALL own mentor coaching policy, hint-ladder behavior, context limits, hidden-material protection, fallback guidance, request state expectations, privacy disclosure requirements, and mentor signal boundaries.
+
+#### Scenario: Lesson challenge consumes guardrails
+GIVEN a learner uses mentor help in a lesson challenge
+WHEN mentor behavior is invoked
+THEN lesson challenge owns the lesson UI, code draft, test execution, and challenge attempt state
+AND AI mentor guardrails owns the coaching policy and mentor behavior boundaries.
+
+#### Scenario: Code Prompts consume guardrails
+GIVEN a learner uses mentor help in a Code Prompt
+WHEN mentor behavior is invoked
+THEN Code Prompts and Deliveries owns workspace, Delivery, evaluation, review, and revision behavior
+AND AI mentor guardrails owns the coaching policy and mentor behavior boundaries.
+
+#### Scenario: Advanced AI review remains separate
+GIVEN a feature requires AI grading, autonomous Delivery acceptance, generated code review reports, adaptive remediation, or personalized curriculum generation
+WHEN MVP scope is enforced
+THEN that feature is deferred unless a later proposal accepts it
+AND AI mentor guardrails remains focused on learner help behavior.

--- a/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-code-prompts-deliveries/spec.md
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-code-prompts-deliveries/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Code Prompt Mentor Guardrail Boundary
+The Code Prompts and Deliveries capability SHALL use AI mentor guardrails for prompt help while retaining ownership of workspace, Delivery, evaluation, review, and revision behavior.
+
+#### Scenario: Prompt mentor uses guardrails
+GIVEN a learner asks for mentor help inside a Code Prompt
+WHEN mentor behavior is invoked
+THEN Code Prompts and Deliveries provides relevant prompt, workspace, Delivery checklist, evaluation, and attempt context within authorized scope
+AND academy-ai-mentor-guardrails owns no-direct-answer, hint-ladder, scope, hidden-material, fallback, and request-state expectations.
+
+#### Scenario: Delivery remains learner-authored
+GIVEN mentor guidance is displayed during Code Prompt work
+WHEN the learner prepares or submits a Delivery
+THEN Code Prompts and Deliveries remains authoritative for the workspace and Delivery submission
+AND mentor guidance does not create, submit, or accept a Delivery on behalf of the learner.
+
+#### Scenario: Prompt evaluation remains protected
+GIVEN a Code Prompt uses hidden checks, protected rubrics, or internal review guidance
+WHEN mentor help is requested
+THEN Code Prompts and Deliveries provides only allowed learner-visible evaluation context
+AND AI mentor guardrails prevents exposing protected evaluation material.

--- a/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-content-health-dashboard/spec.md
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-content-health-dashboard/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Mentor Usage Health Boundary
+The content health dashboard capability SHALL consume mentor usage signals only after mentor guardrails define allowed signal boundaries.
+
+#### Scenario: Mentor usage contributes to health
+GIVEN mentor usage facts exist for published lessons, focused challenges, or Code Prompts
+WHEN content health summarizes help-seeking behavior
+THEN content health may display aggregate mentor usage signals according to privacy and authorization rules
+AND academy-ai-mentor-guardrails remains authoritative for mentor behavior policy.
+
+#### Scenario: Mentor usage does not expose prompt content by default
+GIVEN content health summarizes mentor usage
+WHEN an admin views aggregate content health
+THEN content health does not expose full learner mentor conversations by default
+AND uses learner-level mentor details only through authorized support workflows.
+
+#### Scenario: Guardrails remain separate from health analysis
+GIVEN content health identifies high mentor usage for a content item
+WHEN the signal is reviewed
+THEN content health owns the operational interpretation
+AND AI mentor guardrails owns changes to mentor coaching policy.

--- a/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-lesson-challenge/spec.md
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-lesson-challenge/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Lesson Challenge Mentor Guardrail Boundary
+The lesson challenge capability SHALL use AI mentor guardrails for mentor coaching behavior while retaining ownership of lesson challenge workflow and state.
+
+#### Scenario: Lesson mentor uses guardrails
+GIVEN a learner asks the mentor for help inside a lesson challenge
+WHEN mentor behavior is invoked
+THEN lesson challenge provides the relevant lesson, code, test, and attempt context within authorized scope
+AND academy-ai-mentor-guardrails owns no-direct-answer, hint-ladder, scope, hidden-material, fallback, and request-state expectations.
+
+#### Scenario: Challenge workflow remains lesson-owned
+GIVEN mentor guidance is displayed in a lesson challenge
+WHEN the learner edits code, runs tests, resets, or completes the challenge
+THEN lesson challenge remains authoritative for code draft, test execution, sandbox safety, completion, and reward behavior
+AND mentor guidance does not directly mutate challenge state.
+
+#### Scenario: Mentor unavailable in lesson
+GIVEN mentor help is unavailable inside a lesson challenge
+WHEN the learner requests help
+THEN lesson challenge presents the unavailable, retry, or authored-hint state defined by mentor guardrails
+AND preserves the learner's current challenge draft and test results.

--- a/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-mvp-scope/spec.md
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-mvp-scope/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: MVP AI Mentor Guardrails Boundary
+The MVP scope SHALL treat AI mentor guardrails as MVP-lite learning support and SHALL defer advanced AI review or automation.
+
+#### Scenario: Guardrails remain MVP-lite
+GIVEN MVP implementation planning begins
+WHEN mentor behavior is planned
+THEN no-direct-answer, hint-ladder, lesson-or-prompt scope, explain-don't-solve, authored-hint fallback, context disclosure, and request-state behavior are included as MVP-lite scope
+AND provider-specific live AI implementation is not required before the learner loop is proven.
+
+#### Scenario: Advanced AI review is deferred
+GIVEN AI grading, autonomous Delivery acceptance, generated code review reports, adaptive remediation, mistake memory, or personalized curriculum generation is proposed
+WHEN MVP scope is enforced
+THEN those features are deferred unless a later proposal accepts them
+AND basic mentor guardrails do not become a broad AI product surface.
+
+#### Scenario: Implementation scaffolding follows guardrails
+GIVEN frontend, backend, or contract scaffolding includes mentor-related surfaces
+WHEN implementation work begins
+THEN the implementation references accepted AI mentor guardrails
+AND does not define conflicting mentor behavior inside implementation-only changes.

--- a/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-privacy-controls/spec.md
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/specs/academy-privacy-controls/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Mentor Privacy Boundary
+The privacy controls capability SHALL define privacy expectations for mentor context, conversation records, retention, export, and erasure without owning mentor coaching behavior.
+
+#### Scenario: Mentor context uses privacy policy
+GIVEN learner task context is shared with mentor behavior
+WHEN privacy requirements are applied
+THEN privacy controls remain authoritative for consent, export, erasure, retention, and sensitive-data handling expectations
+AND AI mentor guardrails remains authoritative for mentor coaching behavior.
+
+#### Scenario: Export includes mentor records
+GIVEN a learner requests a data export
+WHEN exportable learner records include persisted mentor prompts, responses, or metadata
+THEN the export includes those records according to privacy policy
+AND does not include protected system prompts, hidden checks, rubrics, or other learners' data.
+
+#### Scenario: Erasure affects mentor records
+GIVEN a learner's personal data is erased according to policy
+WHEN mentor records exist for that learner
+THEN the system deletes or anonymizes learner-identifying mentor records according to the erasure policy
+AND may retain aggregate non-identifying usage counts when policy permits.

--- a/openspec/changes/define-academy-ai-mentor-guardrails/tasks.md
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/tasks.md
@@ -1,0 +1,26 @@
+## 1. Proposal Review
+
+- [ ] 1.1 Review `academy-mvp-scope`, `academy-lesson-challenge`, `academy-code-prompts-deliveries`, `academy-content-health-dashboard`, and `academy-privacy-controls` for mentor behavior, health signal, and privacy boundaries.
+- [ ] 1.2 Confirm AI mentor guardrails are the next proposal candidate after content health.
+- [ ] 1.3 Confirm mentor guardrails remain MVP-lite and do not absorb AI grading, autonomous review, adaptive remediation, or implementation-specific provider decisions.
+
+## 2. Spec Application
+
+- [ ] 2.1 Add the accepted `academy-ai-mentor-guardrails` capability to baseline specs.
+- [ ] 2.2 Update `academy-lesson-challenge` with mentor guardrail consumption boundaries.
+- [ ] 2.3 Update `academy-code-prompts-deliveries` with prompt mentor guardrail boundaries.
+- [ ] 2.4 Update `academy-content-health-dashboard` with mentor usage signal boundaries.
+- [ ] 2.5 Update `academy-privacy-controls` with mentor privacy boundaries.
+- [ ] 2.6 Update `academy-mvp-scope` with MVP-lite mentor guardrail boundaries.
+
+## 3. Follow-Up Planning
+
+- [ ] 3.1 Update follow-up proposal roadmap if needed after AI mentor guardrails are accepted.
+- [ ] 3.2 Identify whether frontend workspace scaffolding, Spring Boot API scaffolding, or shared contracts should come next.
+- [ ] 3.3 Confirm no application implementation code is included in this capability-definition change.
+
+## 4. Validation
+
+- [ ] 4.1 Run `openspec validate define-academy-ai-mentor-guardrails --strict`.
+- [ ] 4.2 Run `openspec validate --all --strict`.
+- [ ] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.


### PR DESCRIPTION
## Summary

- Adds the OpenSpec proposal `define-academy-ai-mentor-guardrails`.
- Introduces the new `academy-ai-mentor-guardrails` capability.
- Defines no-direct-answer coaching, progressive hint ladders, scoped mentor context, hidden-material protection, authored-hint fallback, mentor request states, privacy/retention expectations, and mentor usage signal boundaries.
- Adds boundary deltas for lesson challenge, Code Prompts and Deliveries, content health dashboard, privacy controls, and MVP scope.

## Notes

This is planning/specification only. It does not implement frontend, backend, provider integration, model prompts, storage, API, or infrastructure code.

## Verification

- `openspec validate define-academy-ai-mentor-guardrails --strict`
- `openspec validate --all --strict`
- `git diff --check HEAD~1 HEAD`