### PR TITLE
docs: apply academy ai mentor guardrails spec

### DIFF
--- a/docs/openspec-follow-up-proposals.md
+++ b/docs/openspec-follow-up-proposals.md
@@ -19,11 +19,11 @@ and `academy-mvp-scope`.
    - Define instructor/admin visibility into stuck learners, failed attempts, prompt delivery outcomes, and content quality signals.
    - Depends on `academy-mvp-scope`.
 
-4. `define-academy-ai-mentor-guardrails` (next)
+4. `define-academy-ai-mentor-guardrails` (accepted)
    - Define no-direct-answer, hint-ladder, lesson/prompt scope, explain-don't-solve, and authored-hint fallback behavior.
    - Depends on `academy-mvp-scope`.
 
-5. `scaffold-frontend-workspaces`
+5. `scaffold-frontend-workspaces` (next)
    - Create `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config` implementation scaffolding.
    - Establish strict TypeScript, Vite, Tailwind CSS, ShadCN, linting, formatting, and workspace scripts.
    - Depends on `academy-monorepo-structure` and should reference `academy-mvp-scope`.
@@ -57,6 +57,6 @@ and `academy-mvp-scope`.
 
 ## First Implementation Recommendation
 
-Start with `define-academy-ai-mentor-guardrails`.
+Start with `scaffold-frontend-workspaces`.
 
-Reason: `academy-code-prompts-deliveries`, `academy-admin-content-management`, and `academy-content-health-dashboard` now define the learner prompt loop, content operations, and operational health visibility. AI mentor guardrails should come next so help behavior is bounded before live AI or authored-hint implementation.
+Reason: `academy-code-prompts-deliveries`, `academy-admin-content-management`, `academy-content-health-dashboard`, and `academy-ai-mentor-guardrails` now define the learner prompt loop, content operations, operational health visibility, and bounded help behavior. Frontend workspace scaffolding should come next so the React web/admin structure can be created against the accepted product boundaries.

--- a/openspec/changes/define-academy-ai-mentor-guardrails/tasks.md
+++ b/openspec/changes/define-academy-ai-mentor-guardrails/tasks.md
@@ -1,26 +1,26 @@
 ## 1. Proposal Review
 
-- [ ] 1.1 Review `academy-mvp-scope`, `academy-lesson-challenge`, `academy-code-prompts-deliveries`, `academy-content-health-dashboard`, and `academy-privacy-controls` for mentor behavior, health signal, and privacy boundaries.
-- [ ] 1.2 Confirm AI mentor guardrails are the next proposal candidate after content health.
-- [ ] 1.3 Confirm mentor guardrails remain MVP-lite and do not absorb AI grading, autonomous review, adaptive remediation, or implementation-specific provider decisions.
+- [x] 1.1 Review `academy-mvp-scope`, `academy-lesson-challenge`, `academy-code-prompts-deliveries`, `academy-content-health-dashboard`, and `academy-privacy-controls` for mentor behavior, health signal, and privacy boundaries.
+- [x] 1.2 Confirm AI mentor guardrails are the next proposal candidate after content health.
+- [x] 1.3 Confirm mentor guardrails remain MVP-lite and do not absorb AI grading, autonomous review, adaptive remediation, or implementation-specific provider decisions.
 
 ## 2. Spec Application
 
-- [ ] 2.1 Add the accepted `academy-ai-mentor-guardrails` capability to baseline specs.
-- [ ] 2.2 Update `academy-lesson-challenge` with mentor guardrail consumption boundaries.
-- [ ] 2.3 Update `academy-code-prompts-deliveries` with prompt mentor guardrail boundaries.
-- [ ] 2.4 Update `academy-content-health-dashboard` with mentor usage signal boundaries.
-- [ ] 2.5 Update `academy-privacy-controls` with mentor privacy boundaries.
-- [ ] 2.6 Update `academy-mvp-scope` with MVP-lite mentor guardrail boundaries.
+- [x] 2.1 Add the accepted `academy-ai-mentor-guardrails` capability to baseline specs.
+- [x] 2.2 Update `academy-lesson-challenge` with mentor guardrail consumption boundaries.
+- [x] 2.3 Update `academy-code-prompts-deliveries` with prompt mentor guardrail boundaries.
+- [x] 2.4 Update `academy-content-health-dashboard` with mentor usage signal boundaries.
+- [x] 2.5 Update `academy-privacy-controls` with mentor privacy boundaries.
+- [x] 2.6 Update `academy-mvp-scope` with MVP-lite mentor guardrail boundaries.
 
 ## 3. Follow-Up Planning
 
-- [ ] 3.1 Update follow-up proposal roadmap if needed after AI mentor guardrails are accepted.
-- [ ] 3.2 Identify whether frontend workspace scaffolding, Spring Boot API scaffolding, or shared contracts should come next.
-- [ ] 3.3 Confirm no application implementation code is included in this capability-definition change.
+- [x] 3.1 Update follow-up proposal roadmap if needed after AI mentor guardrails are accepted.
+- [x] 3.2 Identify whether frontend workspace scaffolding, Spring Boot API scaffolding, or shared contracts should come next.
+- [x] 3.3 Confirm no application implementation code is included in this capability-definition change.
 
 ## 4. Validation
 
-- [ ] 4.1 Run `openspec validate define-academy-ai-mentor-guardrails --strict`.
-- [ ] 4.2 Run `openspec validate --all --strict`.
-- [ ] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.
+- [x] 4.1 Run `openspec validate define-academy-ai-mentor-guardrails --strict`.
+- [x] 4.2 Run `openspec validate --all --strict`.
+- [x] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.

--- a/openspec/specs/academy-ai-mentor-guardrails/spec.md
+++ b/openspec/specs/academy-ai-mentor-guardrails/spec.md
@@ -1,0 +1,197 @@
+# Academy AI Mentor Guardrails Specification
+
+## Purpose
+
+Define the Presstronic Academy AI mentor guardrails capability.
+
+This specification captures MVP-limited mentor coaching policy, no-direct-answer behavior, progressive hint ladders, scoped context, hidden-material protection, authored-hint fallback, request states, privacy and retention expectations, mentor usage signal boundaries, and ownership boundaries across lesson challenges and Code Prompts. It does not specify provider-specific prompts, model selection, token budgets, moderation tooling, database schemas, API endpoints, frontend implementation, or live AI integration.
+
+## Requirements
+
+### Requirement: Mentor Coaching Contract
+The system SHALL provide AI mentor behavior that supports learning without completing the learner's work for them.
+
+#### Scenario: Mentor gives coaching guidance
+GIVEN a learner asks for help in a supported lesson or Code Prompt context
+WHEN mentor guidance is available
+THEN the mentor explains relevant concepts, asks diagnostic questions, points to observed evidence, and suggests next investigation steps
+AND preserves learner responsibility for the final solution or Delivery.
+
+#### Scenario: Mentor refuses direct answer request
+GIVEN a learner asks the mentor for a complete solution, final code, hidden answer, or finished Delivery
+WHEN the mentor responds
+THEN the mentor refuses to provide the direct answer
+AND redirects to a hint, explanation, debugging step, or smaller question the learner can act on.
+
+#### Scenario: Mentor explains without solving
+GIVEN a learner asks why something is failing
+WHEN the mentor has enough task context
+THEN the mentor explains the likely concept or failure mode
+AND does not replace the learner's code, implementation notes, or Delivery evidence with a completed answer.
+
+### Requirement: Hint Ladder
+The system SHALL support progressive hint behavior that increases specificity without jumping directly to a solution.
+
+#### Scenario: First hint is broad
+GIVEN a learner asks for help before receiving prior hints for the same issue
+WHEN the mentor responds
+THEN the mentor starts with a conceptual or diagnostic hint
+AND avoids implementation-level instructions unless the learner context requires basic orientation.
+
+#### Scenario: Later hints become more specific
+GIVEN a learner continues to struggle after earlier hints
+WHEN the mentor responds again for the same issue
+THEN the mentor may provide a more specific hint, targeted example, or debugging checklist
+AND still avoids providing a complete solution.
+
+#### Scenario: Hint ladder uses current signals
+GIVEN the mentor has access to current code, test results, Delivery status, or evaluation feedback
+WHEN the mentor chooses a hint level
+THEN the mentor uses those signals to avoid repeating irrelevant generic advice
+AND keeps the next step tied to the current learner task.
+
+### Requirement: Scope and Context Limits
+The system SHALL limit mentor assistance to the active learning context and disclosed learner work.
+
+#### Scenario: Lesson context
+GIVEN a learner asks for mentor help inside a lesson challenge
+WHEN mentor context is prepared
+THEN the system may include lesson content, challenge instructions, current code, latest test results, acceptance criteria, and relevant conversation history
+AND excludes unrelated profile, billing, private account, and cross-course data by default.
+
+#### Scenario: Code Prompt context
+GIVEN a learner asks for mentor help inside a Code Prompt
+WHEN mentor context is prepared
+THEN the system may include prompt brief, objective, constraints, starting point, Delivery checklist, learner workspace context, evaluation feedback, and relevant conversation history
+AND excludes unrelated learner data by default.
+
+#### Scenario: Out-of-scope request
+GIVEN a learner asks for help unrelated to the active lesson or prompt
+WHEN the mentor responds
+THEN the mentor redirects the learner back to the active task when possible
+AND avoids giving unsupported broad advice that conflicts with the learning objective.
+
+### Requirement: Hidden Material Protection
+The system SHALL prevent mentor behavior from revealing protected answers, hidden checks, rubrics, or evaluation internals.
+
+#### Scenario: Hidden tests are protected
+GIVEN a challenge or Code Prompt uses hidden tests or protected checks
+WHEN the learner asks about hidden test implementation
+THEN the mentor does not reveal hidden test code, exact assertions, or protected fixtures
+AND may explain the visible failure category or concept being assessed.
+
+#### Scenario: Rubric internals are protected
+GIVEN a Code Prompt has internal evaluation guidance or review rubrics
+WHEN the learner asks the mentor for the rubric or scoring shortcut
+THEN the mentor does not reveal protected rubric details
+AND may summarize public evaluation expectations already visible to the learner.
+
+#### Scenario: Solution material is protected
+GIVEN authored solution code, reference implementations, or instructor-only notes exist
+WHEN mentor context is prepared or mentor output is generated
+THEN the system prevents those protected materials from being exposed to the learner.
+
+### Requirement: Authored-Hint Fallback
+The system SHALL support authored hints as a fallback or alternative to live AI mentor responses.
+
+#### Scenario: Authored hint used
+GIVEN a live mentor response is unavailable, disabled, rate-limited, or not approved for the current context
+WHEN the learner requests help
+THEN the system can provide an authored hint that matches the lesson, challenge, prompt, or current failure signal
+AND indicates when only authored guidance is available.
+
+#### Scenario: No matching authored hint
+GIVEN no live mentor response is available
+AND no matching authored hint exists
+WHEN the learner requests help
+THEN the system displays a recoverable unavailable state
+AND suggests reviewing the current brief, tests, constraints, or visible feedback.
+
+#### Scenario: Authored hints follow guardrails
+GIVEN authored hints are configured for a lesson, challenge, or Code Prompt
+WHEN a hint is displayed
+THEN the hint follows no-direct-answer, hint-ladder, scope, and hidden-material protection requirements.
+
+### Requirement: Mentor Request States
+The system SHALL handle mentor availability, pending, cancellation, failure, retry, and usage-limit states.
+
+#### Scenario: Mentor request pending
+GIVEN the learner submits a mentor question
+WHEN a mentor response is being generated or retrieved
+THEN the system displays pending state
+AND prevents duplicate sends for the same prompt.
+
+#### Scenario: Mentor request canceled
+GIVEN a mentor response is pending
+WHEN cancellation is available and the learner cancels
+THEN the system stops or abandons the response where feasible
+AND preserves the learner's prompt text or conversation state.
+
+#### Scenario: Mentor request failure
+GIVEN a mentor request fails
+WHEN the failure is displayed
+THEN the system provides retryable feedback
+AND does not invent mentor guidance or claim the request succeeded.
+
+#### Scenario: Mentor usage limited
+GIVEN mentor usage limits apply
+WHEN the learner reaches a configured limit
+THEN the system explains the limit
+AND may offer authored hints or non-AI guidance when available.
+
+### Requirement: Mentor Privacy and Retention
+The system SHALL disclose mentor context sharing and handle mentor records according to privacy requirements.
+
+#### Scenario: Context disclosure
+GIVEN a learner uses mentor help
+WHEN the mentor entry point or prompt area renders
+THEN the system discloses the task context that may be shared with the mentor
+AND avoids implying unrelated learner data is shared.
+
+#### Scenario: Mentor records retained
+GIVEN mentor conversation records are persisted
+WHEN the records are stored
+THEN the system associates them with the learner, task context, and attempt where applicable
+AND applies retention, export, and erasure behavior defined by privacy controls.
+
+#### Scenario: Sensitive data minimization
+GIVEN a learner enters secrets, credentials, payment data, or unrelated personal data into a mentor prompt
+WHEN mentor processing occurs
+THEN the system minimizes, blocks, redacts, or warns according to product policy where feasible
+AND does not require unrelated sensitive data for mentor help.
+
+### Requirement: Mentor Signal Boundary
+The system SHALL allow mentor usage facts to be consumed by content health only as aggregate or authorized support signals.
+
+#### Scenario: Aggregate mentor usage signal
+GIVEN mentor usage events exist for a lesson, challenge, or Code Prompt
+WHEN content health summarizes help-seeking behavior
+THEN content health may consume aggregate mentor usage counts, repeated-help indicators, and unresolved-help indicators
+AND mentor guardrails remain authoritative for mentor behavior policy.
+
+#### Scenario: Learner-level mentor support signal
+GIVEN an authorized instructor or support admin views learner-level support context
+WHEN mentor usage facts are included
+THEN the system exposes only mentor metadata or conversation details allowed by privacy policy and authorization scope
+AND does not expose unrelated learner data.
+
+### Requirement: Mentor Responsibility Boundary
+The AI mentor guardrails capability SHALL own mentor coaching policy, hint-ladder behavior, context limits, hidden-material protection, fallback guidance, request state expectations, privacy disclosure requirements, and mentor signal boundaries.
+
+#### Scenario: Lesson challenge consumes guardrails
+GIVEN a learner uses mentor help in a lesson challenge
+WHEN mentor behavior is invoked
+THEN lesson challenge owns the lesson UI, code draft, test execution, and challenge attempt state
+AND AI mentor guardrails owns the coaching policy and mentor behavior boundaries.
+
+#### Scenario: Code Prompts consume guardrails
+GIVEN a learner uses mentor help in a Code Prompt
+WHEN mentor behavior is invoked
+THEN Code Prompts and Deliveries owns workspace, Delivery, evaluation, review, and revision behavior
+AND AI mentor guardrails owns the coaching policy and mentor behavior boundaries.
+
+#### Scenario: Advanced AI review remains separate
+GIVEN a feature requires AI grading, autonomous Delivery acceptance, generated code review reports, adaptive remediation, or personalized curriculum generation
+WHEN MVP scope is enforced
+THEN that feature is deferred unless a later proposal accepts it
+AND AI mentor guardrails remains focused on learner help behavior.

--- a/openspec/specs/academy-code-prompts-deliveries/spec.md
+++ b/openspec/specs/academy-code-prompts-deliveries/spec.md
@@ -278,3 +278,24 @@ GIVEN content health processing is delayed or unavailable
 WHEN a learner submits a Delivery or receives an evaluation result
 THEN Code Prompts and Deliveries preserves the learner workflow
 AND does not require the health dashboard to be available for prompt evaluation or review.
+
+### Requirement: Code Prompt Mentor Guardrail Boundary
+The Code Prompts and Deliveries capability SHALL use AI mentor guardrails for prompt help while retaining ownership of workspace, Delivery, evaluation, review, and revision behavior.
+
+#### Scenario: Prompt mentor uses guardrails
+GIVEN a learner asks for mentor help inside a Code Prompt
+WHEN mentor behavior is invoked
+THEN Code Prompts and Deliveries provides relevant prompt, workspace, Delivery checklist, evaluation, and attempt context within authorized scope
+AND academy-ai-mentor-guardrails owns no-direct-answer, hint-ladder, scope, hidden-material, fallback, and request-state expectations.
+
+#### Scenario: Delivery remains learner-authored
+GIVEN mentor guidance is displayed during Code Prompt work
+WHEN the learner prepares or submits a Delivery
+THEN Code Prompts and Deliveries remains authoritative for the workspace and Delivery submission
+AND mentor guidance does not create, submit, or accept a Delivery on behalf of the learner.
+
+#### Scenario: Prompt evaluation remains protected
+GIVEN a Code Prompt uses hidden checks, protected rubrics, or internal review guidance
+WHEN mentor help is requested
+THEN Code Prompts and Deliveries provides only allowed learner-visible evaluation context
+AND AI mentor guardrails prevents exposing protected evaluation material.

--- a/openspec/specs/academy-content-health-dashboard/spec.md
+++ b/openspec/specs/academy-content-health-dashboard/spec.md
@@ -167,3 +167,24 @@ GIVEN learner-facing dashboard data is rendered
 WHEN content health data exists
 THEN the learner dashboard does not expose admin content health views
 AND content health remains an admin/instructor operational capability.
+
+### Requirement: Mentor Usage Health Boundary
+The content health dashboard capability SHALL consume mentor usage signals only after mentor guardrails define allowed signal boundaries.
+
+#### Scenario: Mentor usage contributes to health
+GIVEN mentor usage facts exist for published lessons, focused challenges, or Code Prompts
+WHEN content health summarizes help-seeking behavior
+THEN content health may display aggregate mentor usage signals according to privacy and authorization rules
+AND academy-ai-mentor-guardrails remains authoritative for mentor behavior policy.
+
+#### Scenario: Mentor usage does not expose prompt content by default
+GIVEN content health summarizes mentor usage
+WHEN an admin views aggregate content health
+THEN content health does not expose full learner mentor conversations by default
+AND uses learner-level mentor details only through authorized support workflows.
+
+#### Scenario: Guardrails remain separate from health analysis
+GIVEN content health identifies high mentor usage for a content item
+WHEN the signal is reviewed
+THEN content health owns the operational interpretation
+AND AI mentor guardrails owns changes to mentor coaching policy.

--- a/openspec/specs/academy-lesson-challenge/spec.md
+++ b/openspec/specs/academy-lesson-challenge/spec.md
@@ -386,3 +386,24 @@ GIVEN content health processing is delayed or unavailable
 WHEN a learner runs tests or completes a focused challenge
 THEN lesson challenge preserves the learner workflow
 AND does not require the health dashboard to be available for challenge execution.
+
+### Requirement: Lesson Challenge Mentor Guardrail Boundary
+The lesson challenge capability SHALL use AI mentor guardrails for mentor coaching behavior while retaining ownership of lesson challenge workflow and state.
+
+#### Scenario: Lesson mentor uses guardrails
+GIVEN a learner asks the mentor for help inside a lesson challenge
+WHEN mentor behavior is invoked
+THEN lesson challenge provides the relevant lesson, code, test, and attempt context within authorized scope
+AND academy-ai-mentor-guardrails owns no-direct-answer, hint-ladder, scope, hidden-material, fallback, and request-state expectations.
+
+#### Scenario: Challenge workflow remains lesson-owned
+GIVEN mentor guidance is displayed in a lesson challenge
+WHEN the learner edits code, runs tests, resets, or completes the challenge
+THEN lesson challenge remains authoritative for code draft, test execution, sandbox safety, completion, and reward behavior
+AND mentor guidance does not directly mutate challenge state.
+
+#### Scenario: Mentor unavailable in lesson
+GIVEN mentor help is unavailable inside a lesson challenge
+WHEN the learner requests help
+THEN lesson challenge presents the unavailable, retry, or authored-hint state defined by mentor guardrails
+AND preserves the learner's current challenge draft and test results.

--- a/openspec/specs/academy-mvp-scope/spec.md
+++ b/openspec/specs/academy-mvp-scope/spec.md
@@ -198,3 +198,24 @@ GIVEN help or mentor behavior contributes learner signals
 WHEN AI mentor behavior is planned
 THEN AI mentor guardrails remain a separate proposal
 AND content health may later consume mentor usage signals only after those guardrails are accepted.
+
+### Requirement: MVP AI Mentor Guardrails Boundary
+The MVP scope SHALL treat AI mentor guardrails as MVP-lite learning support and SHALL defer advanced AI review or automation.
+
+#### Scenario: Guardrails remain MVP-lite
+GIVEN MVP implementation planning begins
+WHEN mentor behavior is planned
+THEN no-direct-answer, hint-ladder, lesson-or-prompt scope, explain-don't-solve, authored-hint fallback, context disclosure, and request-state behavior are included as MVP-lite scope
+AND provider-specific live AI implementation is not required before the learner loop is proven.
+
+#### Scenario: Advanced AI review is deferred
+GIVEN AI grading, autonomous Delivery acceptance, generated code review reports, adaptive remediation, mistake memory, or personalized curriculum generation is proposed
+WHEN MVP scope is enforced
+THEN those features are deferred unless a later proposal accepts them
+AND basic mentor guardrails do not become a broad AI product surface.
+
+#### Scenario: Implementation scaffolding follows guardrails
+GIVEN frontend, backend, or contract scaffolding includes mentor-related surfaces
+WHEN implementation work begins
+THEN the implementation references accepted AI mentor guardrails
+AND does not define conflicting mentor behavior inside implementation-only changes.

--- a/openspec/specs/academy-privacy-controls/spec.md
+++ b/openspec/specs/academy-privacy-controls/spec.md
@@ -193,3 +193,24 @@ GIVEN a learner requests a data export
 WHEN exportable learner records include content health source facts tied to that learner
 THEN the export includes those records according to privacy policy
 AND does not include aggregate metrics about other learners.
+
+### Requirement: Mentor Privacy Boundary
+The privacy controls capability SHALL define privacy expectations for mentor context, conversation records, retention, export, and erasure without owning mentor coaching behavior.
+
+#### Scenario: Mentor context uses privacy policy
+GIVEN learner task context is shared with mentor behavior
+WHEN privacy requirements are applied
+THEN privacy controls remain authoritative for consent, export, erasure, retention, and sensitive-data handling expectations
+AND AI mentor guardrails remains authoritative for mentor coaching behavior.
+
+#### Scenario: Export includes mentor records
+GIVEN a learner requests a data export
+WHEN exportable learner records include persisted mentor prompts, responses, or metadata
+THEN the export includes those records according to privacy policy
+AND does not include protected system prompts, hidden checks, rubrics, or other learners' data.
+
+#### Scenario: Erasure affects mentor records
+GIVEN a learner's personal data is erased according to policy
+WHEN mentor records exist for that learner
+THEN the system deletes or anonymizes learner-identifying mentor records according to the erasure policy
+AND may retain aggregate non-identifying usage counts when policy permits.


### PR DESCRIPTION
## Summary

- Applies the accepted `define-academy-ai-mentor-guardrails` change into baseline OpenSpec specs.
- Adds the new baseline `academy-ai-mentor-guardrails` capability.
- Adds mentor guardrail boundary requirements to lesson challenge, Code Prompts and Deliveries, content health dashboard, privacy controls, and MVP scope.
- Marks the change tasks complete and updates the follow-up roadmap to make frontend workspace scaffolding the next proposal candidate.

## Notes

This is specification/documentation only. It does not include frontend, backend, provider integration, model prompts, storage, API, or infrastructure implementation.

## Verification

- `openspec validate define-academy-ai-mentor-guardrails --strict`
- `openspec validate --all --strict`
- `git diff --check`