### PR TITLE
docs: propose frontend workspace scaffolding

### DIFF
--- a/openspec/changes/scaffold-frontend-workspaces/.openspec.yaml
+++ b/openspec/changes/scaffold-frontend-workspaces/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/scaffold-frontend-workspaces/README.md
+++ b/openspec/changes/scaffold-frontend-workspaces/README.md
@@ -1,0 +1,3 @@
+# scaffold-frontend-workspaces
+
+Define implementation scaffolding for the learner and admin React workspaces, shared ShadCN-based UI package, strict TypeScript configuration, shared ESLint configuration, Tailwind conventions, routing boundaries, and workspace scripts.

--- a/openspec/changes/scaffold-frontend-workspaces/design.md
+++ b/openspec/changes/scaffold-frontend-workspaces/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The repository has been reset to a monorepo skeleton with placeholder app and package directories. The accepted `academy-monorepo-structure` spec says learner frontend work belongs in `apps/web`, admin/instructor frontend work belongs in `apps/admin`, shared UI belongs in `packages/ui`, TypeScript config belongs in `packages/tsconfig`, and ESLint config belongs in `packages/eslint-config`.
+
+The frontend scaffold should provide enough structure to start real UI work without overbuilding application behavior. It should make the first implementation branch mechanically reliable: installable packages, strict type checking, linting, build commands, Vite app shells, Tailwind/ShadCN conventions, and shared package import paths.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the exact frontend workspace boundaries before implementation.
+- Establish strict TypeScript across frontend apps and shared packages.
+- Use Vite for both React apps.
+- Use Tailwind CSS and ShadCN-compatible component conventions.
+- Use `packages/ui` for reusable UI primitives and Academy component wrappers.
+- Use shared TSConfig and ESLint packages to keep workspace behavior consistent.
+- Keep learner routes/screens in `apps/web` and admin routes/screens in `apps/admin`.
+- Define practical verification commands for the scaffold.
+
+**Non-Goals:**
+
+- Do not implement production learner or admin workflows in this change proposal.
+- Do not define final route trees, data loaders, API clients, auth integration, or state management libraries beyond scaffold needs.
+- Do not implement backend APIs, contracts, database, local infrastructure, live AI, code runner, or deployment.
+- Do not introduce a UI framework other than React/Vite/Tailwind/ShadCN unless a later proposal changes the stack.
+
+## Decisions
+
+### Decision: Use two Vite React apps
+
+`apps/web` and `apps/admin` should be separate deployable React apps. They share configuration and UI packages, but routes, screens, and workflow state stay app-owned.
+
+Alternative considered: one app with learner/admin route partitions. Separate apps match the accepted monorepo boundary and keep future deployment/access policies cleaner.
+
+### Decision: Keep shared UI low-level at scaffold time
+
+`packages/ui` should start with tokens, primitives, utilities, and a small proof component surface. It should not absorb page layouts, app routes, or domain workflows.
+
+Alternative considered: move all UI composition into `packages/ui`. That would make the shared package too broad before the app surfaces are implemented.
+
+### Decision: Centralize TypeScript and lint configuration
+
+Strict TypeScript and shared lint rules should be implemented through workspace packages so both apps and future packages inherit the same defaults.
+
+Alternative considered: duplicate config in each app. That is faster initially but makes strictness drift likely as the monorepo grows.
+
+### Decision: Scaffold for ShadCN compatibility, not a hidden component vendor
+
+ShadCN components are source-owned. The scaffold should support ShadCN conventions, Tailwind tokens, class utilities, and component composition without treating ShadCN as a runtime dependency boundary.
+
+Alternative considered: wrap everything in a generic design system abstraction immediately. That adds indirection before the first real UI flows exist.
+
+## Risks / Trade-offs
+
+- Scaffold can sprawl into product implementation -> Keep the first implementation to buildable apps, shared config, and minimal example surfaces.
+- Shared UI can become too broad -> Keep app workflows app-owned and shared package reusable.
+- Strict TypeScript can slow setup if configs are too clever -> Prefer clear configs and explicit workspace references.
+- Tailwind/ShadCN setup can diverge between apps -> Share theme tokens and conventions through `packages/ui` plus documented app config.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Apply the `academy-frontend-workspaces` baseline spec and related boundary deltas.
+3. Implement the scaffold in a follow-up code PR that creates package manifests, configs, minimal app entry points, and verification scripts.
+4. After frontend scaffolding is implemented and archived, continue with Spring Boot API scaffolding or shared API contracts based on dependency order.
+
+## Open Questions
+
+- Should the first scaffold use Vitest from day one, or only typecheck/lint/build until components gain behavior?
+- Should routing start with React Router immediately, or remain implementation-defined until first screen work?
+- Should `packages/ui` own Tailwind preset/config directly, or expose CSS/tokens consumed by app-level Tailwind configs?
+- Should Storybook be deferred until reusable UI components are more mature?

--- a/openspec/changes/scaffold-frontend-workspaces/proposal.md
+++ b/openspec/changes/scaffold-frontend-workspaces/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The accepted product and architecture specs now define the learner loop, admin content operations, content health, AI mentor guardrails, visual design, and monorepo boundaries. The repository still only contains placeholder frontend directories. Before generating React code, the frontend scaffold needs an accepted plan for workspace layout, strict TypeScript, shared UI ownership, ShadCN/Tailwind conventions, and verification commands.
+
+This proposal turns the approved frontend monorepo shape into a concrete scaffolding target while keeping implementation details reviewable before files are generated.
+
+## What Changes
+
+- Define `apps/web` as the learner-facing React workspace using Vite, strict TypeScript, Tailwind CSS, ShadCN-compatible components, and app-owned routes/screens.
+- Define `apps/admin` as the admin/instructor React workspace using the same frontend stack and admin-owned routes/screens.
+- Define `packages/ui` as the shared Academy component package for ShadCN-wrapped primitives, design tokens, accessibility behavior, and reusable variants.
+- Define `packages/tsconfig` as the shared strict TypeScript configuration package.
+- Define `packages/eslint-config` as the shared lint configuration package.
+- Define root and workspace scripts for dev, build, lint, typecheck, test/check, and formatting where applicable.
+- Define route/layout, styling, dependency, and placeholder replacement boundaries for frontend implementation.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-frontend-workspaces`: Frontend workspace scaffolding for learner/admin React apps and shared frontend packages.
+
+### Modified Capabilities
+
+- `academy-monorepo-structure`: Adds concrete frontend scaffolding expectations under the accepted app/package boundaries.
+- `academy-design-system-components`: Clarifies package ownership for shared ShadCN-based components.
+- `academy-visual-design`: Clarifies that scaffolded Tailwind/theme configuration must preserve accepted visual design tokens and constraints.
+- `academy-shell`: Clarifies that learner app routing/layout scaffolding must support the accepted shell boundaries.
+- `academy-mvp-scope`: Recognizes frontend workspace scaffolding as the next implementation step after accepted product boundary proposals.
+
+## Impact
+
+- Affects future file creation under `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config`.
+- Affects root `package.json`, workspace package manifests, TypeScript configs, ESLint configs, Tailwind/PostCSS configs, Vite configs, and README guidance in a later apply/implementation step.
+- Does not implement backend APIs, generated API clients, authentication integration, persistence, live AI, code execution, or production deployment.
+- Leaves `apps/api`, `apps/worker`, `apps/gateway`, `packages/contracts`, `services/*`, and `infra/*` implementation to later proposals.

--- a/openspec/changes/scaffold-frontend-workspaces/specs/academy-design-system-components/spec.md
+++ b/openspec/changes/scaffold-frontend-workspaces/specs/academy-design-system-components/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Shared UI Package Boundary
+The design-system-components capability SHALL treat `packages/ui` as the implementation home for reusable Academy components and ShadCN-compatible primitives shared across frontend apps.
+
+#### Scenario: Reusable component belongs in shared UI
+GIVEN a UI component is reusable across learner and admin apps
+WHEN the component is implemented
+THEN it lives in `packages/ui`
+AND exports a stable API for consuming frontend workspaces.
+
+#### Scenario: App-specific composition stays app-owned
+GIVEN a component or composition depends on learner or admin workflow state
+WHEN implementation ownership is reviewed
+THEN the app-specific composition lives in `apps/web` or `apps/admin`
+AND `packages/ui` remains responsible for reusable primitives, variants, tokens, and accessibility behavior.
+
+#### Scenario: ShadCN source ownership
+GIVEN ShadCN components are added
+WHEN their source files are committed
+THEN they are treated as source-owned project components
+AND are adapted to Academy visual design and accessibility requirements.

--- a/openspec/changes/scaffold-frontend-workspaces/specs/academy-frontend-workspaces/spec.md
+++ b/openspec/changes/scaffold-frontend-workspaces/specs/academy-frontend-workspaces/spec.md
@@ -1,0 +1,149 @@
+## ADDED Requirements
+
+### Requirement: Frontend Workspace Topology
+The repository SHALL scaffold frontend workspaces for learner, admin, shared UI, shared TypeScript configuration, and shared ESLint configuration under the accepted monorepo boundaries.
+
+#### Scenario: Frontend workspaces exist
+GIVEN frontend scaffolding is implemented
+WHEN a contributor reviews the workspace layout
+THEN `apps/web` contains the learner-facing React application
+AND `apps/admin` contains the admin and instructor React application
+AND `packages/ui` contains reusable Academy UI components and styling utilities
+AND `packages/tsconfig` contains shared TypeScript configuration
+AND `packages/eslint-config` contains shared ESLint configuration.
+
+#### Scenario: Placeholder docs are replaced or retained intentionally
+GIVEN a scaffolded workspace previously contained only placeholder documentation
+WHEN implementation creates the real workspace
+THEN placeholder-only files are replaced or updated to describe the actual workspace
+AND no obsolete placeholder text remains as the primary documentation for an implemented workspace.
+
+#### Scenario: Non-frontend placeholders remain inactive
+GIVEN frontend scaffolding is implemented
+WHEN backend, worker, gateway, contract, service, or infrastructure placeholders exist
+THEN those areas remain placeholder-only unless a separate accepted proposal activates them.
+
+### Requirement: Learner Web App Scaffold
+The `apps/web` workspace SHALL scaffold a learner-facing React app with strict TypeScript, Vite, Tailwind CSS, and ShadCN-compatible UI consumption.
+
+#### Scenario: Learner app builds
+GIVEN frontend dependencies are installed
+WHEN the learner app build command runs
+THEN `apps/web` compiles as a Vite React TypeScript application
+AND consumes shared configuration from workspace packages where applicable.
+
+#### Scenario: Learner app owns learner routes
+GIVEN learner-facing screens are implemented
+WHEN route or screen ownership is reviewed
+THEN public and authenticated learner routes live in `apps/web`
+AND shared UI primitives remain in `packages/ui`.
+
+#### Scenario: Learner app references accepted shell boundaries
+GIVEN `apps/web` scaffolds app layout or routing
+WHEN the scaffold defines public and authenticated route structure
+THEN it supports landing/auth screens outside the app shell
+AND supports authenticated learner screens inside the app shell.
+
+### Requirement: Admin App Scaffold
+The `apps/admin` workspace SHALL scaffold an admin and instructor React app with strict TypeScript, Vite, Tailwind CSS, and ShadCN-compatible UI consumption.
+
+#### Scenario: Admin app builds
+GIVEN frontend dependencies are installed
+WHEN the admin app build command runs
+THEN `apps/admin` compiles as a Vite React TypeScript application
+AND consumes shared configuration from workspace packages where applicable.
+
+#### Scenario: Admin app owns admin routes
+GIVEN admin or instructor screens are implemented
+WHEN route or screen ownership is reviewed
+THEN content management, content health, support, reporting, moderation, and administrative routes live in `apps/admin`
+AND shared UI primitives remain in `packages/ui`.
+
+#### Scenario: Admin scaffold remains separate from learner app
+GIVEN learner and admin workspaces exist
+WHEN a contributor adds app-specific workflow state
+THEN learner workflow state remains in `apps/web`
+AND admin workflow state remains in `apps/admin`.
+
+### Requirement: Shared UI Package Scaffold
+The `packages/ui` workspace SHALL scaffold reusable Academy UI primitives, styling utilities, and ShadCN-compatible component ownership without owning application routes or workflows.
+
+#### Scenario: Shared UI package builds
+GIVEN frontend dependencies are installed
+WHEN the shared UI build or typecheck command runs
+THEN `packages/ui` compiles reusable TypeScript React exports
+AND exposes components through stable package exports.
+
+#### Scenario: Shared UI owns reusable components
+GIVEN a component is used by both learner and admin apps
+WHEN it wraps ShadCN primitives, tokens, accessibility behavior, or reusable variants
+THEN it lives in `packages/ui`
+AND app-specific screens, data loading, and workflow state remain in the consuming app.
+
+#### Scenario: Shared UI preserves Academy visual design
+GIVEN shared components or tokens are scaffolded
+WHEN styling is defined
+THEN the scaffold follows Academy visual design constraints for colors, typography, geometry, iconography, spacing, and motion
+AND does not introduce conflicting global visual rules.
+
+### Requirement: Shared Frontend Configuration
+The repository SHALL provide shared strict TypeScript and ESLint configuration packages for frontend workspaces.
+
+#### Scenario: Shared TypeScript config
+GIVEN frontend workspaces are scaffolded
+WHEN TypeScript configuration is reviewed
+THEN `packages/tsconfig` provides shared strict TypeScript config
+AND frontend apps and packages extend it instead of duplicating strictness settings.
+
+#### Scenario: Shared ESLint config
+GIVEN frontend workspaces are scaffolded
+WHEN lint configuration is reviewed
+THEN `packages/eslint-config` provides shared frontend lint configuration
+AND frontend apps and packages consume it instead of maintaining unrelated lint rules.
+
+#### Scenario: Strict type checking
+GIVEN the workspace typecheck command runs
+WHEN TypeScript evaluates frontend apps and packages
+THEN strict type checking is enabled
+AND scaffolded source does not rely on implicit `any` or disabled strictness.
+
+### Requirement: Frontend Workspace Scripts
+The repository SHALL expose root and workspace scripts that support frontend development, build, lint, typecheck, and quality checks.
+
+#### Scenario: Root recursive scripts
+GIVEN frontend workspaces are scaffolded
+WHEN a contributor runs root quality commands
+THEN root scripts invoke matching workspace scripts for build, lint, typecheck, test or check where present
+AND do not require contributors to manually enter each app directory for routine verification.
+
+#### Scenario: App development scripts
+GIVEN the learner and admin apps are scaffolded
+WHEN a contributor starts local frontend development
+THEN each app exposes a development server script
+AND ports or startup instructions avoid ambiguity between learner and admin apps.
+
+#### Scenario: Verification commands are documented
+GIVEN frontend scaffolding is implemented
+WHEN a contributor reads workspace documentation
+THEN the documentation identifies install, dev, build, lint, typecheck, and quality commands for the scaffolded frontend.
+
+### Requirement: Frontend Dependency Boundaries
+The frontend scaffold SHALL keep dependencies aligned with workspace ownership and avoid premature product implementation.
+
+#### Scenario: Shared dependency placement
+GIVEN a dependency is used only by one app
+WHEN dependencies are declared
+THEN it belongs to that app workspace
+AND shared dependencies are placed where workspace package management can resolve them consistently.
+
+#### Scenario: API clients deferred
+GIVEN backend contracts and generated clients are not yet accepted
+WHEN frontend scaffolding is implemented
+THEN API client generation and backend integration are deferred
+AND any data access remains mock, placeholder, or implementation-free according to the scaffold scope.
+
+#### Scenario: Product workflows deferred
+GIVEN frontend scaffolding is implemented
+WHEN learner, admin, mentor, content health, or content authoring product workflows are considered
+THEN the scaffold may include minimal placeholders or route shells
+AND does not implement production workflow behavior before focused feature proposals accept it.

--- a/openspec/changes/scaffold-frontend-workspaces/specs/academy-monorepo-structure/spec.md
+++ b/openspec/changes/scaffold-frontend-workspaces/specs/academy-monorepo-structure/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Frontend Scaffolding Application
+The monorepo structure capability SHALL allow accepted frontend scaffolding to activate `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config` while preserving other placeholder boundaries.
+
+#### Scenario: Frontend placeholders become workspaces
+GIVEN `scaffold-frontend-workspaces` is accepted and applied
+WHEN frontend implementation scaffolding is created
+THEN `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config` become active pnpm workspaces
+AND their ownership remains consistent with application and shared package boundaries.
+
+#### Scenario: Backend and service placeholders stay inactive
+GIVEN frontend scaffolding is implemented
+WHEN a contributor reviews `apps/api`, `apps/worker`, `apps/gateway`, `packages/contracts`, or `services/*`
+THEN those areas remain placeholder-only unless a separate accepted proposal activates them
+AND frontend scaffolding does not introduce backend implementation there.
+
+#### Scenario: Workspace metadata matches active packages
+GIVEN frontend scaffolding is implemented
+WHEN root workspace metadata and package manifests are reviewed
+THEN they include the active frontend apps and packages
+AND do not include stale package references for directories that remain placeholder-only.

--- a/openspec/changes/scaffold-frontend-workspaces/specs/academy-mvp-scope/spec.md
+++ b/openspec/changes/scaffold-frontend-workspaces/specs/academy-mvp-scope/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: MVP Frontend Scaffolding Sequence
+The MVP scope SHALL allow frontend workspace scaffolding after product boundaries are accepted and before detailed learner/admin workflow implementation.
+
+#### Scenario: Frontend scaffold is next implementation step
+GIVEN Code Prompts, admin content management, content health, and AI mentor guardrails are accepted
+WHEN implementation scaffolding begins
+THEN frontend workspace scaffolding may proceed as the next MVP implementation step
+AND it references accepted product boundaries instead of redefining them.
+
+#### Scenario: Scaffold avoids product workflow implementation
+GIVEN frontend workspaces are scaffolded
+WHEN MVP scope is enforced
+THEN the scaffold includes buildable app/package foundations, shared config, styling setup, and minimal placeholders
+AND defers production learner/admin workflows to focused implementation proposals or tasks.
+
+#### Scenario: Backend scaffolding remains separate
+GIVEN frontend workspace scaffolding is underway
+WHEN Spring Boot API, contracts, local infrastructure, or service activation work is considered
+THEN those areas remain separate proposal candidates
+AND are not implemented as part of frontend scaffolding.

--- a/openspec/changes/scaffold-frontend-workspaces/specs/academy-shell/spec.md
+++ b/openspec/changes/scaffold-frontend-workspaces/specs/academy-shell/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Learner Frontend Shell Scaffold Boundary
+The shell capability SHALL guide learner app routing and layout scaffolding without requiring full screen implementation during frontend workspace setup.
+
+#### Scenario: Shell route shape supported
+GIVEN `apps/web` is scaffolded
+WHEN initial routing or layout placeholders are created
+THEN the scaffold can represent public landing/auth surfaces separately from authenticated app-shell surfaces
+AND does not need to implement every learner screen behavior in the scaffold change.
+
+#### Scenario: Shell implementation remains learner-owned
+GIVEN the learner app shell is implemented later
+WHEN shell code is added
+THEN it lives in `apps/web`
+AND reusable shell UI primitives may live in `packages/ui` only when they are app-agnostic.

--- a/openspec/changes/scaffold-frontend-workspaces/specs/academy-visual-design/spec.md
+++ b/openspec/changes/scaffold-frontend-workspaces/specs/academy-visual-design/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Frontend Scaffold Visual Token Boundary
+The visual-design capability SHALL guide scaffolded Tailwind, CSS, and shared UI token configuration for frontend workspaces.
+
+#### Scenario: Tailwind uses Academy tokens
+GIVEN frontend Tailwind configuration is scaffolded
+WHEN colors, typography, spacing, geometry, or motion tokens are defined
+THEN the scaffold reflects accepted Academy visual design constraints
+AND does not introduce conflicting global theme values.
+
+#### Scenario: App scaffolds do not redefine visual contract
+GIVEN `apps/web` or `apps/admin` defines local styles
+WHEN style ownership is reviewed
+THEN app styles consume shared visual tokens where feasible
+AND do not redefine global art direction, typography roles, color semantics, geometry, or iconography.

--- a/openspec/changes/scaffold-frontend-workspaces/tasks.md
+++ b/openspec/changes/scaffold-frontend-workspaces/tasks.md
@@ -1,0 +1,27 @@
+## 1. Proposal Review
+
+- [ ] 1.1 Review `academy-monorepo-structure`, `academy-shell`, `academy-design-system-components`, `academy-visual-design`, and `academy-mvp-scope` for frontend workspace boundaries.
+- [ ] 1.2 Review current repository root, app placeholders, package placeholders, `package.json`, and `pnpm-workspace.yaml` for scaffold impact.
+- [ ] 1.3 Confirm frontend scaffolding is the next proposal candidate after AI mentor guardrails.
+- [ ] 1.4 Confirm this proposal does not implement production learner/admin workflows, backend APIs, contracts, infrastructure, or services.
+
+## 2. Spec Application
+
+- [ ] 2.1 Add the accepted `academy-frontend-workspaces` capability to baseline specs.
+- [ ] 2.2 Update `academy-monorepo-structure` with frontend scaffold activation boundaries.
+- [ ] 2.3 Update `academy-design-system-components` with shared UI package boundaries.
+- [ ] 2.4 Update `academy-visual-design` with frontend scaffold token boundaries.
+- [ ] 2.5 Update `academy-shell` with learner frontend shell scaffold boundaries.
+- [ ] 2.6 Update `academy-mvp-scope` with frontend scaffolding sequence boundaries.
+
+## 3. Implementation Planning
+
+- [ ] 3.1 Define implementation scope for `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config`.
+- [ ] 3.2 Define expected root and workspace scripts for dev, build, lint, typecheck, test/check, and formatting.
+- [ ] 3.3 Identify whether frontend scaffold implementation or Spring Boot API scaffolding should come next after this proposal is accepted.
+
+## 4. Validation
+
+- [ ] 4.1 Run `openspec validate scaffold-frontend-workspaces --strict`.
+- [ ] 4.2 Run `openspec validate --all --strict`.
+- [ ] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.


### PR DESCRIPTION
## Summary

- Adds the OpenSpec proposal `scaffold-frontend-workspaces`.
- Introduces the new `academy-frontend-workspaces` capability.
- Defines frontend scaffolding for `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config`.
- Defines strict TypeScript, Vite, Tailwind CSS, ShadCN-compatible component ownership, shared config, route/layout boundaries, dependency boundaries, and workspace script expectations.
- Adds boundary deltas for monorepo structure, design system components, visual design, shell, and MVP scope.

## Notes

This is planning/specification only. It does not create the React apps or install dependencies yet.

## Verification

- `openspec validate scaffold-frontend-workspaces --strict`
- `openspec validate --all --strict`
- `git diff --check HEAD~1 HEAD`