### PR TITLE
docs: apply frontend workspace scaffolding spec

### DIFF
--- a/docs/openspec-follow-up-proposals.md
+++ b/docs/openspec-follow-up-proposals.md
@@ -23,12 +23,12 @@ and `academy-mvp-scope`.
    - Define no-direct-answer, hint-ladder, lesson/prompt scope, explain-don't-solve, and authored-hint fallback behavior.
    - Depends on `academy-mvp-scope`.
 
-5. `scaffold-frontend-workspaces` (next)
+5. `scaffold-frontend-workspaces` (accepted)
    - Create `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config` implementation scaffolding.
    - Establish strict TypeScript, Vite, Tailwind CSS, ShadCN, linting, formatting, and workspace scripts.
    - Depends on `academy-monorepo-structure` and should reference `academy-mvp-scope`.
 
-6. `scaffold-spring-boot-api`
+6. `scaffold-spring-boot-api` (next)
    - Create the primary `apps/api` Spring Boot application.
    - Establish REST/WebSocket-ready backend structure, health checks, test setup, and local profile conventions.
    - Depends on `academy-monorepo-structure` and should reference `academy-mvp-scope`.
@@ -57,6 +57,6 @@ and `academy-mvp-scope`.
 
 ## First Implementation Recommendation
 
-Start with `scaffold-frontend-workspaces`.
+Start with `scaffold-spring-boot-api`.
 
-Reason: `academy-code-prompts-deliveries`, `academy-admin-content-management`, `academy-content-health-dashboard`, and `academy-ai-mentor-guardrails` now define the learner prompt loop, content operations, operational health visibility, and bounded help behavior. Frontend workspace scaffolding should come next so the React web/admin structure can be created against the accepted product boundaries.
+Reason: `academy-frontend-workspaces` will define the frontend application scaffolding. Spring Boot API scaffolding should come next so the primary REST/WebSocket backend boundary exists before shared contracts and local infrastructure are implemented.

--- a/openspec/changes/scaffold-frontend-workspaces/tasks.md
+++ b/openspec/changes/scaffold-frontend-workspaces/tasks.md
@@ -1,27 +1,27 @@
 ## 1. Proposal Review
 
-- [ ] 1.1 Review `academy-monorepo-structure`, `academy-shell`, `academy-design-system-components`, `academy-visual-design`, and `academy-mvp-scope` for frontend workspace boundaries.
-- [ ] 1.2 Review current repository root, app placeholders, package placeholders, `package.json`, and `pnpm-workspace.yaml` for scaffold impact.
-- [ ] 1.3 Confirm frontend scaffolding is the next proposal candidate after AI mentor guardrails.
-- [ ] 1.4 Confirm this proposal does not implement production learner/admin workflows, backend APIs, contracts, infrastructure, or services.
+- [x] 1.1 Review `academy-monorepo-structure`, `academy-shell`, `academy-design-system-components`, `academy-visual-design`, and `academy-mvp-scope` for frontend workspace boundaries.
+- [x] 1.2 Review current repository root, app placeholders, package placeholders, `package.json`, and `pnpm-workspace.yaml` for scaffold impact.
+- [x] 1.3 Confirm frontend scaffolding is the next proposal candidate after AI mentor guardrails.
+- [x] 1.4 Confirm this proposal does not implement production learner/admin workflows, backend APIs, contracts, infrastructure, or services.
 
 ## 2. Spec Application
 
-- [ ] 2.1 Add the accepted `academy-frontend-workspaces` capability to baseline specs.
-- [ ] 2.2 Update `academy-monorepo-structure` with frontend scaffold activation boundaries.
-- [ ] 2.3 Update `academy-design-system-components` with shared UI package boundaries.
-- [ ] 2.4 Update `academy-visual-design` with frontend scaffold token boundaries.
-- [ ] 2.5 Update `academy-shell` with learner frontend shell scaffold boundaries.
-- [ ] 2.6 Update `academy-mvp-scope` with frontend scaffolding sequence boundaries.
+- [x] 2.1 Add the accepted `academy-frontend-workspaces` capability to baseline specs.
+- [x] 2.2 Update `academy-monorepo-structure` with frontend scaffold activation boundaries.
+- [x] 2.3 Update `academy-design-system-components` with shared UI package boundaries.
+- [x] 2.4 Update `academy-visual-design` with frontend scaffold token boundaries.
+- [x] 2.5 Update `academy-shell` with learner frontend shell scaffold boundaries.
+- [x] 2.6 Update `academy-mvp-scope` with frontend scaffolding sequence boundaries.
 
 ## 3. Implementation Planning
 
-- [ ] 3.1 Define implementation scope for `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config`.
-- [ ] 3.2 Define expected root and workspace scripts for dev, build, lint, typecheck, test/check, and formatting.
-- [ ] 3.3 Identify whether frontend scaffold implementation or Spring Boot API scaffolding should come next after this proposal is accepted.
+- [x] 3.1 Define implementation scope for `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config`.
+- [x] 3.2 Define expected root and workspace scripts for dev, build, lint, typecheck, test/check, and formatting.
+- [x] 3.3 Identify whether frontend scaffold implementation or Spring Boot API scaffolding should come next after this proposal is accepted.
 
 ## 4. Validation
 
-- [ ] 4.1 Run `openspec validate scaffold-frontend-workspaces --strict`.
-- [ ] 4.2 Run `openspec validate --all --strict`.
-- [ ] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.
+- [x] 4.1 Run `openspec validate scaffold-frontend-workspaces --strict`.
+- [x] 4.2 Run `openspec validate --all --strict`.
+- [x] 4.3 Confirm the proposal branch contains only OpenSpec proposal artifacts unless documentation alignment edits are intentionally included.

--- a/openspec/specs/academy-design-system-components/spec.md
+++ b/openspec/specs/academy-design-system-components/spec.md
@@ -614,3 +614,24 @@ THEN the component does not persist the state externally.
 GIVEN a component is activated
 WHEN no consuming screen callback performs a network action
 THEN the component itself does not issue network requests.
+
+### Requirement: Shared UI Package Boundary
+The design-system-components capability SHALL treat `packages/ui` as the implementation home for reusable Academy components and ShadCN-compatible primitives shared across frontend apps.
+
+#### Scenario: Reusable component belongs in shared UI
+GIVEN a UI component is reusable across learner and admin apps
+WHEN the component is implemented
+THEN it lives in `packages/ui`
+AND exports a stable API for consuming frontend workspaces.
+
+#### Scenario: App-specific composition stays app-owned
+GIVEN a component or composition depends on learner or admin workflow state
+WHEN implementation ownership is reviewed
+THEN the app-specific composition lives in `apps/web` or `apps/admin`
+AND `packages/ui` remains responsible for reusable primitives, variants, tokens, and accessibility behavior.
+
+#### Scenario: ShadCN source ownership
+GIVEN ShadCN components are added
+WHEN their source files are committed
+THEN they are treated as source-owned project components
+AND are adapted to Academy visual design and accessibility requirements.

--- a/openspec/specs/academy-frontend-workspaces/spec.md
+++ b/openspec/specs/academy-frontend-workspaces/spec.md
@@ -1,0 +1,157 @@
+# Academy Frontend Workspaces Specification
+
+## Purpose
+
+Define the Presstronic Academy frontend workspace scaffolding capability.
+
+This specification captures learner/admin React app scaffolding, shared UI package ownership, strict TypeScript configuration, shared ESLint configuration, workspace scripts, dependency boundaries, ShadCN/Tailwind conventions, and placeholder replacement boundaries. It does not specify backend APIs, generated API clients, authentication integration, persistence, live AI, code execution, production deployment, or production learner/admin workflow behavior.
+
+## Requirements
+
+### Requirement: Frontend Workspace Topology
+The repository SHALL scaffold frontend workspaces for learner, admin, shared UI, shared TypeScript configuration, and shared ESLint configuration under the accepted monorepo boundaries.
+
+#### Scenario: Frontend workspaces exist
+GIVEN frontend scaffolding is implemented
+WHEN a contributor reviews the workspace layout
+THEN `apps/web` contains the learner-facing React application
+AND `apps/admin` contains the admin and instructor React application
+AND `packages/ui` contains reusable Academy UI components and styling utilities
+AND `packages/tsconfig` contains shared TypeScript configuration
+AND `packages/eslint-config` contains shared ESLint configuration.
+
+#### Scenario: Placeholder docs are replaced or retained intentionally
+GIVEN a scaffolded workspace previously contained only placeholder documentation
+WHEN implementation creates the real workspace
+THEN placeholder-only files are replaced or updated to describe the actual workspace
+AND no obsolete placeholder text remains as the primary documentation for an implemented workspace.
+
+#### Scenario: Non-frontend placeholders remain inactive
+GIVEN frontend scaffolding is implemented
+WHEN backend, worker, gateway, contract, service, or infrastructure placeholders exist
+THEN those areas remain placeholder-only unless a separate accepted proposal activates them.
+
+### Requirement: Learner Web App Scaffold
+The `apps/web` workspace SHALL scaffold a learner-facing React app with strict TypeScript, Vite, Tailwind CSS, and ShadCN-compatible UI consumption.
+
+#### Scenario: Learner app builds
+GIVEN frontend dependencies are installed
+WHEN the learner app build command runs
+THEN `apps/web` compiles as a Vite React TypeScript application
+AND consumes shared configuration from workspace packages where applicable.
+
+#### Scenario: Learner app owns learner routes
+GIVEN learner-facing screens are implemented
+WHEN route or screen ownership is reviewed
+THEN public and authenticated learner routes live in `apps/web`
+AND shared UI primitives remain in `packages/ui`.
+
+#### Scenario: Learner app references accepted shell boundaries
+GIVEN `apps/web` scaffolds app layout or routing
+WHEN the scaffold defines public and authenticated route structure
+THEN it supports landing/auth screens outside the app shell
+AND supports authenticated learner screens inside the app shell.
+
+### Requirement: Admin App Scaffold
+The `apps/admin` workspace SHALL scaffold an admin and instructor React app with strict TypeScript, Vite, Tailwind CSS, and ShadCN-compatible UI consumption.
+
+#### Scenario: Admin app builds
+GIVEN frontend dependencies are installed
+WHEN the admin app build command runs
+THEN `apps/admin` compiles as a Vite React TypeScript application
+AND consumes shared configuration from workspace packages where applicable.
+
+#### Scenario: Admin app owns admin routes
+GIVEN admin or instructor screens are implemented
+WHEN route or screen ownership is reviewed
+THEN content management, content health, support, reporting, moderation, and administrative routes live in `apps/admin`
+AND shared UI primitives remain in `packages/ui`.
+
+#### Scenario: Admin scaffold remains separate from learner app
+GIVEN learner and admin workspaces exist
+WHEN a contributor adds app-specific workflow state
+THEN learner workflow state remains in `apps/web`
+AND admin workflow state remains in `apps/admin`.
+
+### Requirement: Shared UI Package Scaffold
+The `packages/ui` workspace SHALL scaffold reusable Academy UI primitives, styling utilities, and ShadCN-compatible component ownership without owning application routes or workflows.
+
+#### Scenario: Shared UI package builds
+GIVEN frontend dependencies are installed
+WHEN the shared UI build or typecheck command runs
+THEN `packages/ui` compiles reusable TypeScript React exports
+AND exposes components through stable package exports.
+
+#### Scenario: Shared UI owns reusable components
+GIVEN a component is used by both learner and admin apps
+WHEN it wraps ShadCN primitives, tokens, accessibility behavior, or reusable variants
+THEN it lives in `packages/ui`
+AND app-specific screens, data loading, and workflow state remain in the consuming app.
+
+#### Scenario: Shared UI preserves Academy visual design
+GIVEN shared components or tokens are scaffolded
+WHEN styling is defined
+THEN the scaffold follows Academy visual design constraints for colors, typography, geometry, iconography, spacing, and motion
+AND does not introduce conflicting global visual rules.
+
+### Requirement: Shared Frontend Configuration
+The repository SHALL provide shared strict TypeScript and ESLint configuration packages for frontend workspaces.
+
+#### Scenario: Shared TypeScript config
+GIVEN frontend workspaces are scaffolded
+WHEN TypeScript configuration is reviewed
+THEN `packages/tsconfig` provides shared strict TypeScript config
+AND frontend apps and packages extend it instead of duplicating strictness settings.
+
+#### Scenario: Shared ESLint config
+GIVEN frontend workspaces are scaffolded
+WHEN lint configuration is reviewed
+THEN `packages/eslint-config` provides shared frontend lint configuration
+AND frontend apps and packages consume it instead of maintaining unrelated lint rules.
+
+#### Scenario: Strict type checking
+GIVEN the workspace typecheck command runs
+WHEN TypeScript evaluates frontend apps and packages
+THEN strict type checking is enabled
+AND scaffolded source does not rely on implicit `any` or disabled strictness.
+
+### Requirement: Frontend Workspace Scripts
+The repository SHALL expose root and workspace scripts that support frontend development, build, lint, typecheck, and quality checks.
+
+#### Scenario: Root recursive scripts
+GIVEN frontend workspaces are scaffolded
+WHEN a contributor runs root quality commands
+THEN root scripts invoke matching workspace scripts for build, lint, typecheck, test or check where present
+AND do not require contributors to manually enter each app directory for routine verification.
+
+#### Scenario: App development scripts
+GIVEN the learner and admin apps are scaffolded
+WHEN a contributor starts local frontend development
+THEN each app exposes a development server script
+AND ports or startup instructions avoid ambiguity between learner and admin apps.
+
+#### Scenario: Verification commands are documented
+GIVEN frontend scaffolding is implemented
+WHEN a contributor reads workspace documentation
+THEN the documentation identifies install, dev, build, lint, typecheck, and quality commands for the scaffolded frontend.
+
+### Requirement: Frontend Dependency Boundaries
+The frontend scaffold SHALL keep dependencies aligned with workspace ownership and avoid premature product implementation.
+
+#### Scenario: Shared dependency placement
+GIVEN a dependency is used only by one app
+WHEN dependencies are declared
+THEN it belongs to that app workspace
+AND shared dependencies are placed where workspace package management can resolve them consistently.
+
+#### Scenario: API clients deferred
+GIVEN backend contracts and generated clients are not yet accepted
+WHEN frontend scaffolding is implemented
+THEN API client generation and backend integration are deferred
+AND any data access remains mock, placeholder, or implementation-free according to the scaffold scope.
+
+#### Scenario: Product workflows deferred
+GIVEN frontend scaffolding is implemented
+WHEN learner, admin, mentor, content health, or content authoring product workflows are considered
+THEN the scaffold may include minimal placeholders or route shells
+AND does not implement production workflow behavior before focused feature proposals accept it.

--- a/openspec/specs/academy-monorepo-structure/spec.md
+++ b/openspec/specs/academy-monorepo-structure/spec.md
@@ -140,3 +140,24 @@ GIVEN the structure proposal is accepted
 WHEN work begins on frontend, backend, contracts, local infrastructure, or a future service extraction
 THEN each substantial implementation area references the accepted structure capability
 AND defines its own affected files, verification commands, and acceptance criteria.
+
+### Requirement: Frontend Scaffolding Application
+The monorepo structure capability SHALL allow accepted frontend scaffolding to activate `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config` while preserving other placeholder boundaries.
+
+#### Scenario: Frontend placeholders become workspaces
+GIVEN `scaffold-frontend-workspaces` is accepted and applied
+WHEN frontend implementation scaffolding is created
+THEN `apps/web`, `apps/admin`, `packages/ui`, `packages/tsconfig`, and `packages/eslint-config` become active pnpm workspaces
+AND their ownership remains consistent with application and shared package boundaries.
+
+#### Scenario: Backend and service placeholders stay inactive
+GIVEN frontend scaffolding is implemented
+WHEN a contributor reviews `apps/api`, `apps/worker`, `apps/gateway`, `packages/contracts`, or `services/*`
+THEN those areas remain placeholder-only unless a separate accepted proposal activates them
+AND frontend scaffolding does not introduce backend implementation there.
+
+#### Scenario: Workspace metadata matches active packages
+GIVEN frontend scaffolding is implemented
+WHEN root workspace metadata and package manifests are reviewed
+THEN they include the active frontend apps and packages
+AND do not include stale package references for directories that remain placeholder-only.

--- a/openspec/specs/academy-mvp-scope/spec.md
+++ b/openspec/specs/academy-mvp-scope/spec.md
@@ -219,3 +219,24 @@ GIVEN frontend, backend, or contract scaffolding includes mentor-related surface
 WHEN implementation work begins
 THEN the implementation references accepted AI mentor guardrails
 AND does not define conflicting mentor behavior inside implementation-only changes.
+
+### Requirement: MVP Frontend Scaffolding Sequence
+The MVP scope SHALL allow frontend workspace scaffolding after product boundaries are accepted and before detailed learner/admin workflow implementation.
+
+#### Scenario: Frontend scaffold is next implementation step
+GIVEN Code Prompts, admin content management, content health, and AI mentor guardrails are accepted
+WHEN implementation scaffolding begins
+THEN frontend workspace scaffolding may proceed as the next MVP implementation step
+AND it references accepted product boundaries instead of redefining them.
+
+#### Scenario: Scaffold avoids product workflow implementation
+GIVEN frontend workspaces are scaffolded
+WHEN MVP scope is enforced
+THEN the scaffold includes buildable app/package foundations, shared config, styling setup, and minimal placeholders
+AND defers production learner/admin workflows to focused implementation proposals or tasks.
+
+#### Scenario: Backend scaffolding remains separate
+GIVEN frontend workspace scaffolding is underway
+WHEN Spring Boot API, contracts, local infrastructure, or service activation work is considered
+THEN those areas remain separate proposal candidates
+AND are not implemented as part of frontend scaffolding.

--- a/openspec/specs/academy-shell/spec.md
+++ b/openspec/specs/academy-shell/spec.md
@@ -324,3 +324,18 @@ The shell capability SHALL own top-level screen resolution, protected route acce
 - **WHEN** the learner changes the active theme
 - **THEN** the shell owns document-level theme application and synchronization rules
 - **AND** the surface owns only its local control presentation.
+
+### Requirement: Learner Frontend Shell Scaffold Boundary
+The shell capability SHALL guide learner app routing and layout scaffolding without requiring full screen implementation during frontend workspace setup.
+
+#### Scenario: Shell route shape supported
+GIVEN `apps/web` is scaffolded
+WHEN initial routing or layout placeholders are created
+THEN the scaffold can represent public landing/auth surfaces separately from authenticated app-shell surfaces
+AND does not need to implement every learner screen behavior in the scaffold change.
+
+#### Scenario: Shell implementation remains learner-owned
+GIVEN the learner app shell is implemented later
+WHEN shell code is added
+THEN it lives in `apps/web`
+AND reusable shell UI primitives may live in `packages/ui` only when they are app-agnostic.

--- a/openspec/specs/academy-visual-design/spec.md
+++ b/openspec/specs/academy-visual-design/spec.md
@@ -206,3 +206,18 @@ The visual-design capability SHALL be the authoritative owner for Academy art di
 - **GIVEN** a mockup or design handoff contains example values or content
 - **WHEN** those values are not explicitly required by the visual-design capability
 - **THEN** other capabilities treat them as examples rather than independent product contracts.
+
+### Requirement: Frontend Scaffold Visual Token Boundary
+The visual-design capability SHALL guide scaffolded Tailwind, CSS, and shared UI token configuration for frontend workspaces.
+
+#### Scenario: Tailwind uses Academy tokens
+GIVEN frontend Tailwind configuration is scaffolded
+WHEN colors, typography, spacing, geometry, or motion tokens are defined
+THEN the scaffold reflects accepted Academy visual design constraints
+AND does not introduce conflicting global theme values.
+
+#### Scenario: App scaffolds do not redefine visual contract
+GIVEN `apps/web` or `apps/admin` defines local styles
+WHEN style ownership is reviewed
+THEN app styles consume shared visual tokens where feasible
+AND do not redefine global art direction, typography roles, color semantics, geometry, or iconography.


### PR DESCRIPTION
## Summary
- Applies accepted `scaffold-frontend-workspaces` into baseline OpenSpec specs.
- Adds new baseline `academy-frontend-workspaces`.
- Adds boundary requirements to monorepo structure, design system components, visual design, shell, and MVP scope.
- Marks change tasks complete and advances the roadmap to Spring Boot API scaffolding next.
- Spec/docs only; no React app or dependency installation.

## Verification
- `openspec validate scaffold-frontend-workspaces --strict`
- `openspec validate --all --strict`
- `git diff --check`