### PR TITLE
docs: propose Spring Boot API scaffold

### DIFF
--- a/openspec/changes/scaffold-spring-boot-api/.openspec.yaml
+++ b/openspec/changes/scaffold-spring-boot-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/scaffold-spring-boot-api/design.md
+++ b/openspec/changes/scaffold-spring-boot-api/design.md
@@ -1,0 +1,64 @@
+## Context
+
+The repository currently has placeholder application and package directories plus accepted OpenSpec boundaries for frontend workspaces, monorepo structure, MVP scope, Code Prompts/Deliveries, admin content management, content health, and AI mentor guardrails. `academy-monorepo-structure` identifies `apps/api` as the primary Spring Boot backend application for REST APIs, WebSocket workflows, authentication integration, and core Academy backend orchestration before any service-specific extraction is accepted.
+
+This change proposes the `apps/api` scaffold only. It should establish a buildable Spring Boot application foundation that later API, contract, persistence, auth, WebSocket, worker, infrastructure, and service proposals can build on.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the backend scaffold boundary for `apps/api` using Spring Boot and Gradle Kotlin DSL.
+- Establish source, test, configuration, local profile, health/readiness, and verification expectations.
+- Prepare REST-first and WebSocket-ready conventions without requiring product endpoints.
+- Keep backend scaffolding aligned with accepted MVP and monorepo boundaries.
+- Preserve future compatibility with `packages/contracts`, local infrastructure, worker jobs, and independently deployable services.
+
+**Non-Goals:**
+
+- Implement learner, admin, content, Code Prompt, Delivery, mentor, or content health API behavior.
+- Define database schemas, migrations, repositories, or persistence entities.
+- Generate OpenAPI clients or activate `packages/contracts`.
+- Implement authentication/authorization behavior beyond preserving its future integration boundary.
+- Implement worker, gateway, code-runner, notification, billing, or GraphQL behavior.
+- Configure production deployment or local Docker Compose services.
+
+## Decisions
+
+### Use a Single Primary Spring Boot API App
+
+`apps/api` will become the active backend application boundary before service extraction. REST controllers, WebSocket endpoints, authentication integration, and orchestration that do not yet justify separate deployment belong there.
+
+Alternative considered: create multiple Spring Boot services immediately. That would add operational and contract complexity before the MVP learning loop proves where independent scaling or isolation is actually needed.
+
+### Use Gradle Kotlin DSL for Backend Build Metadata
+
+The scaffold will use Gradle Kotlin DSL for the Spring Boot application because the repository has already documented Spring Boot with Gradle Kotlin DSL as the backend direction. Root scripts may delegate to the backend build where useful, but the backend should remain understandable from `apps/api`.
+
+Alternative considered: use Maven for the API. Maven is valid for Spring Boot, but mixing it into a repo that has selected Gradle Kotlin DSL would create unnecessary build-system divergence.
+
+### Prefer Feature-Oriented Java Packages
+
+The scaffold should organize future code by feature or bounded area, with shared cross-cutting support kept explicit, instead of defaulting to broad layer-only packages. Initial scaffold code can stay minimal, but documentation and package names should steer future implementation toward feature ownership.
+
+Alternative considered: controller/service/repository top-level packages. That is familiar, but it tends to scatter feature behavior across layers and makes future OpenSpec-to-code ownership harder to trace.
+
+### Establish Health/Readiness Before Product APIs
+
+The scaffold should include observable health/readiness behavior so local and future deployment checks have a stable surface before product endpoints exist. This may use Spring Boot Actuator or a minimal equivalent in the implementation, but it must not imply production domain behavior.
+
+Alternative considered: skip runtime endpoints until product APIs exist. That would make the scaffold harder to verify and harder to wire into future infrastructure work.
+
+### Defer OpenAPI Contracts Until API Shape Exists
+
+The scaffold should be REST-first and OpenAPI-ready, but it should not create generated clients or `packages/contracts` behavior yet. Contract scaffolding should follow once the primary API shape and local runtime conventions are established.
+
+Alternative considered: contract-first stubs in the same change. That would blur ownership with the planned `setup-shared-api-contracts` proposal and force API design before feature-specific backend requirements are accepted.
+
+## Risks / Trade-offs
+
+- Framework scaffold drift -> Keep the implementation minimal, buildable, and documented; avoid placeholder product APIs that later need removal.
+- Premature coupling to persistence or infrastructure -> Defer database, Redis, S3, Docker Compose, and migration behavior to focused proposals.
+- WebSocket readiness mistaken for WebSocket product behavior -> Specify configuration readiness only; require later feature proposals for event contracts and lifecycle behavior.
+- Backend package conventions becoming too abstract -> Use feature/domain package guidance, but let concrete feature packages emerge only when accepted product APIs are implemented.
+- Root script ambiguity in a mixed frontend/backend monorepo -> Define explicit root and app-level verification commands so contributors can run backend checks without guessing.

--- a/openspec/changes/scaffold-spring-boot-api/proposal.md
+++ b/openspec/changes/scaffold-spring-boot-api/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Presstronic Academy needs the primary backend application boundary established before shared API contracts, local infrastructure wiring, and feature-specific API work can be implemented coherently. The monorepo already defines `apps/api` as the Spring Boot home for REST APIs, WebSocket workflows, authentication integration, and core backend orchestration, so the next step is to specify that scaffold without prematurely implementing product behavior.
+
+## What Changes
+
+- Define a new `academy-spring-boot-api` capability for the primary backend scaffold under `apps/api`.
+- Specify Spring Boot and Gradle Kotlin DSL scaffold expectations, including source layout, test layout, strict build verification, local profile conventions, and health/readiness behavior.
+- Establish REST-first and WebSocket-ready boundaries while deferring concrete product endpoints, GraphQL, generated clients, persistence schemas, and infrastructure activation.
+- Update monorepo structure requirements so `apps/api` can become an active backend workspace while `apps/worker`, `apps/gateway`, `packages/contracts`, `services/*`, and infrastructure areas remain placeholder or separately proposed.
+- Update MVP scope requirements so backend scaffolding is recognized as the next foundation after frontend workspace scaffolding, without implementing learner/admin workflows.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-spring-boot-api`: Primary Spring Boot API scaffold, build/test conventions, local runtime profile, health/readiness surfaces, REST/WebSocket readiness, and backend dependency boundaries.
+
+### Modified Capabilities
+
+- `academy-monorepo-structure`: Adds the backend scaffold activation boundary for `apps/api` and keeps worker, gateway, service, contract, and infrastructure areas separate.
+- `academy-mvp-scope`: Adds the MVP sequencing boundary for Spring Boot API scaffolding after frontend workspace scaffolding and before feature-specific backend API implementation.
+
+## Impact
+
+- Affected future code areas: `apps/api`, root build/workspace metadata as needed, backend test configuration, local runtime configuration, and project documentation.
+- Affected future systems: Spring Boot application runtime, health/readiness checks, REST controller conventions, WebSocket configuration readiness, and local development profile conventions.
+- Explicitly deferred: production learner/admin APIs, authentication implementation, database schemas and migrations, generated API contracts, worker jobs, gateway behavior, microservice extraction, Docker Compose service wiring, and GraphQL.

--- a/openspec/changes/scaffold-spring-boot-api/specs/academy-monorepo-structure/spec.md
+++ b/openspec/changes/scaffold-spring-boot-api/specs/academy-monorepo-structure/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Spring Boot API Scaffolding Application
+The monorepo structure capability SHALL allow accepted backend scaffolding to activate `apps/api` as the primary Spring Boot backend workspace while preserving other backend, contract, service, and infrastructure boundaries.
+
+#### Scenario: API placeholder becomes active workspace
+GIVEN `scaffold-spring-boot-api` is accepted and applied
+WHEN backend implementation scaffolding is created
+THEN `apps/api` becomes an active Spring Boot workspace
+AND its ownership remains consistent with the primary API application boundary.
+
+#### Scenario: Worker gateway and services stay inactive
+GIVEN Spring Boot API scaffolding is implemented
+WHEN a contributor reviews `apps/worker`, `apps/gateway`, or `services/*`
+THEN those areas remain placeholder-only unless a separate accepted proposal activates them
+AND API scaffolding does not introduce independently deployable service behavior there.
+
+#### Scenario: Contracts and infrastructure stay separate
+GIVEN Spring Boot API scaffolding is implemented
+WHEN a contributor reviews `packages/contracts` or `infra/*`
+THEN those areas remain placeholder-only or documentation-only unless separate accepted proposals activate them
+AND API scaffolding does not implement generated clients, Docker Compose dependencies, deployment assets, or environment provisioning.
+
+#### Scenario: Workspace metadata matches backend activation
+GIVEN Spring Boot API scaffolding is implemented
+WHEN root workspace metadata and project documentation are reviewed
+THEN they include the active API app where applicable
+AND do not include stale backend package references for directories that remain placeholder-only.

--- a/openspec/changes/scaffold-spring-boot-api/specs/academy-mvp-scope/spec.md
+++ b/openspec/changes/scaffold-spring-boot-api/specs/academy-mvp-scope/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: MVP Spring Boot API Scaffolding Sequence
+The MVP scope SHALL allow primary Spring Boot API scaffolding after frontend workspace boundaries are accepted and before feature-specific backend API implementation.
+
+#### Scenario: API scaffold follows frontend scaffold
+GIVEN frontend workspace scaffolding has been accepted
+WHEN backend implementation scaffolding begins
+THEN Spring Boot API scaffolding may proceed as the next MVP implementation foundation
+AND it references accepted product boundaries instead of redefining learner or admin workflows.
+
+#### Scenario: API scaffold avoids product workflow implementation
+GIVEN the Spring Boot API workspace is scaffolded
+WHEN MVP scope is enforced
+THEN the scaffold includes buildable backend foundations, runtime configuration conventions, health/readiness checks, REST-first conventions, and WebSocket readiness
+AND defers production learner/admin/content/prompt/delivery/mentor workflows to focused implementation proposals or tasks.
+
+#### Scenario: Contracts and infrastructure remain separate
+GIVEN Spring Boot API scaffolding is underway
+WHEN shared API contracts, generated clients, local infrastructure, persistence, worker jobs, or service activation work is considered
+THEN those areas remain separate proposal candidates
+AND are not implemented as part of backend API scaffolding.

--- a/openspec/changes/scaffold-spring-boot-api/specs/academy-spring-boot-api/spec.md
+++ b/openspec/changes/scaffold-spring-boot-api/specs/academy-spring-boot-api/spec.md
@@ -1,0 +1,133 @@
+## ADDED Requirements
+
+### Requirement: Spring Boot API Workspace
+The repository SHALL scaffold `apps/api` as the primary Spring Boot backend application for core Academy REST APIs, WebSocket-ready backend behavior, authentication integration, and backend orchestration.
+
+#### Scenario: API workspace exists
+GIVEN backend API scaffolding is implemented
+WHEN a contributor reviews the workspace layout
+THEN `apps/api` contains the primary Spring Boot application
+AND the workspace can be built and tested independently from frontend app workspaces.
+
+#### Scenario: API workspace replaces placeholder documentation
+GIVEN `apps/api` previously contained only placeholder documentation
+WHEN the Spring Boot scaffold is created
+THEN placeholder-only files are replaced or updated to describe the actual backend workspace
+AND no obsolete placeholder text remains as the primary documentation for the implemented API workspace.
+
+#### Scenario: API remains primary backend boundary
+GIVEN backend behavior is implemented before a service-specific extraction is accepted
+WHEN the behavior exposes REST APIs, WebSocket workflows, authentication integration, or core backend orchestration
+THEN it lives in `apps/api`
+AND does not create an independently deployable service boundary.
+
+### Requirement: Backend Build and Verification Scaffold
+The API workspace SHALL provide Spring Boot build, test, and verification commands using Gradle Kotlin DSL.
+
+#### Scenario: API build command succeeds
+GIVEN backend dependencies are available
+WHEN the API build command runs
+THEN the Spring Boot application compiles
+AND its tests run as part of build verification.
+
+#### Scenario: API test command succeeds
+GIVEN backend dependencies are available
+WHEN the API test command runs
+THEN the scaffolded test suite executes
+AND includes at least one application context or equivalent scaffold verification test.
+
+#### Scenario: Root scripts expose backend verification
+GIVEN backend scaffolding is implemented
+WHEN a contributor reviews root project scripts or documented commands
+THEN routine backend build and test verification can be run from the project root
+AND contributors do not need to infer backend commands from Gradle internals.
+
+### Requirement: API Runtime Configuration Scaffold
+The API workspace SHALL define local runtime configuration conventions without committing secrets or production environment assumptions.
+
+#### Scenario: Local profile exists
+GIVEN the API scaffold is implemented
+WHEN local runtime configuration is reviewed
+THEN a local or development profile convention exists
+AND configuration values are externalized rather than hard-coded as secrets.
+
+#### Scenario: Type-safe configuration boundary
+GIVEN backend configuration grows beyond simple framework settings
+WHEN application-owned configuration is introduced
+THEN it uses type-safe configuration binding
+AND avoids scattering raw environment access throughout domain code.
+
+#### Scenario: Production configuration deferred
+GIVEN deployment-specific configuration is required
+WHEN backend scaffolding is implemented
+THEN production secrets, environment provisioning, and deployment configuration remain deferred to infrastructure or deployment proposals.
+
+### Requirement: Health and Readiness Surface
+The API workspace SHALL expose a minimal health/readiness surface suitable for local verification and future infrastructure wiring.
+
+#### Scenario: Health endpoint available
+GIVEN the API application is running locally
+WHEN a contributor checks the documented health surface
+THEN the application reports that the scaffolded backend is running
+AND the response does not depend on unavailable product databases, queues, object storage, or external services.
+
+#### Scenario: Readiness remains scaffold-level
+GIVEN future infrastructure wiring is not yet implemented
+WHEN readiness behavior is reviewed
+THEN readiness confirms only scaffold-level runtime availability
+AND does not claim production dependency readiness before those dependencies are accepted and wired.
+
+### Requirement: REST-First API Readiness
+The API scaffold SHALL establish REST-first conventions without implementing production product endpoints.
+
+#### Scenario: REST conventions documented
+GIVEN backend scaffolding is implemented
+WHEN a contributor reviews API documentation or package conventions
+THEN REST controllers, request/response DTOs, validation, and error response conventions have an identified home
+AND future product endpoints can follow those conventions.
+
+#### Scenario: Product endpoints deferred
+GIVEN learner, admin, Code Prompt, Delivery, content health, mentor, or billing API behavior is considered
+WHEN only the API scaffold proposal is being implemented
+THEN production product endpoints remain deferred
+AND require focused proposals or tasks before implementation.
+
+#### Scenario: Contract generation deferred
+GIVEN shared generated clients are not yet accepted
+WHEN the API scaffold is implemented
+THEN OpenAPI documents, generated TypeScript clients, and shared schema package behavior remain deferred to a separate contracts proposal.
+
+### Requirement: WebSocket Readiness Boundary
+The API scaffold SHALL allow future WebSocket workflows while deferring concrete event contracts and live product behavior.
+
+#### Scenario: WebSocket dependencies or conventions are bounded
+GIVEN backend scaffolding includes WebSocket readiness
+WHEN dependencies, configuration, or package documentation is reviewed
+THEN they identify where future WebSocket configuration and handlers will live
+AND do not implement live product events before an accepted workflow proposal defines them.
+
+#### Scenario: WebSocket lifecycle deferred
+GIVEN a workflow needs live progress, streaming status, collaboration, notifications, or long-running job updates
+WHEN WebSocket behavior is proposed later
+THEN that proposal defines authorization, connection lifecycle, event payloads, retry behavior, and fallback behavior
+AND does not rely on scaffold-only requirements for product semantics.
+
+### Requirement: Backend Dependency Boundaries
+The API scaffold SHALL include only dependencies needed for a buildable backend foundation and SHALL defer persistence, infrastructure, and service integrations until focused proposals accept them.
+
+#### Scenario: Persistence dependencies deferred
+GIVEN database schemas and migrations are not accepted yet
+WHEN the API scaffold dependencies are reviewed
+THEN JPA, migration tooling, repository code, and database-specific configuration are included only if needed for scaffold verification
+AND otherwise remain deferred to persistence or feature proposals.
+
+#### Scenario: External integrations deferred
+GIVEN Redis, S3-compatible storage, email providers, billing providers, AI providers, or code execution systems are not yet wired
+WHEN backend scaffolding is implemented
+THEN those integrations remain absent or placeholder-documented
+AND no credentials or production endpoints are committed.
+
+#### Scenario: Service extraction deferred
+GIVEN future services may exist for code running, notifications, or billing
+WHEN backend scaffolding is implemented
+THEN `services/*`, `apps/worker`, and `apps/gateway` remain inactive unless a separate accepted proposal activates them.

--- a/openspec/changes/scaffold-spring-boot-api/tasks.md
+++ b/openspec/changes/scaffold-spring-boot-api/tasks.md
@@ -1,0 +1,41 @@
+## 1. Repository and Build Setup
+
+- [ ] 1.1 Replace the `apps/api` placeholder with a Spring Boot application scaffold using Gradle Kotlin DSL.
+- [ ] 1.2 Add backend build metadata needed for Java, Spring Boot, dependency management, tests, and application packaging.
+- [ ] 1.3 Wire root-level or documented commands so contributors can run API build and tests from the project root.
+- [ ] 1.4 Keep `apps/worker`, `apps/gateway`, `packages/contracts`, `services/*`, and `infra/*` placeholder-only unless a separate accepted proposal activates them.
+
+## 2. Application Source Scaffold
+
+- [ ] 2.1 Create the main Spring Boot application entry point under an Academy-owned Java package.
+- [ ] 2.2 Establish feature/domain-oriented package guidance for future REST, WebSocket, auth, and orchestration code.
+- [ ] 2.3 Add minimal scaffold documentation for `apps/api`, including local run, build, test, and health-check commands.
+- [ ] 2.4 Avoid adding learner, admin, content, Code Prompt, Delivery, mentor, billing, or content health product endpoints in this scaffold.
+
+## 3. Runtime Configuration and Observability
+
+- [ ] 3.1 Add local/development configuration conventions without committing secrets or production assumptions.
+- [ ] 3.2 Add or document type-safe configuration boundaries for future application-owned settings.
+- [ ] 3.3 Provide a minimal health/readiness surface that verifies scaffold runtime availability.
+- [ ] 3.4 Ensure health/readiness does not require PostgreSQL, Redis, S3, queues, AI providers, billing providers, or code execution systems before those integrations are accepted.
+
+## 4. REST and WebSocket Readiness
+
+- [ ] 4.1 Document where future REST controllers, DTOs, validation, and API error handling conventions will live.
+- [ ] 4.2 Add only scaffold-level REST behavior needed for runtime verification, if any.
+- [ ] 4.3 Document where future WebSocket configuration and handlers will live.
+- [ ] 4.4 Defer WebSocket event contracts, connection authorization, retries, and fallback behavior to future workflow proposals.
+
+## 5. Testing and Verification
+
+- [ ] 5.1 Add a scaffold test that verifies the Spring application context or equivalent backend bootstrap.
+- [ ] 5.2 Run the API build command.
+- [ ] 5.3 Run the API test command.
+- [ ] 5.4 Run `openspec validate scaffold-spring-boot-api --strict`.
+- [ ] 5.5 Run `openspec validate --all --strict`.
+- [ ] 5.6 Run `git diff --check`.
+
+## 6. Follow-Up Boundaries
+
+- [ ] 6.1 Identify `setup-shared-api-contracts` as the next proposal candidate after Spring Boot API scaffolding is accepted and applied.
+- [ ] 6.2 Confirm persistence, migrations, generated clients, local infrastructure, worker jobs, gateway behavior, microservice extraction, and GraphQL remain deferred.


### PR DESCRIPTION
## Summary
- Proposes `scaffold-spring-boot-api` as the next OpenSpec change.
- Adds the new `academy-spring-boot-api` capability delta.
- Updates monorepo and MVP scope deltas for backend scaffold activation boundaries.
- Defines implementation tasks for a buildable Spring Boot/Gradle Kotlin DSL API scaffold.
- Proposal only; no backend code, dependencies, database schema, contracts, infra, or services are implemented.

## Verification
- `openspec validate scaffold-spring-boot-api --strict`
- `openspec validate --all --strict`
- `git diff --check`