### PR TITLE
feat: scaffold Spring Boot API

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,4 +1,48 @@
 # API App
 
-Primary Java Spring Boot application for REST APIs, WebSockets, authentication,
-and core Academy workflows.
+Primary Java Spring Boot application for REST APIs, WebSocket-ready workflows,
+authentication integration, and core Academy backend orchestration.
+
+This scaffold is intentionally small. It establishes the buildable backend
+workspace and runtime conventions without implementing learner, admin, content,
+Code Prompt, Delivery, mentor, billing, or content health product endpoints.
+
+## Commands
+
+Run from the repository root:
+
+```bash
+pnpm api:build
+pnpm api:test
+pnpm api:bootRun
+```
+
+Run directly from this workspace:
+
+```bash
+gradle -p apps/api build
+gradle -p apps/api test
+gradle -p apps/api bootRun --args='--spring.profiles.active=local'
+```
+
+Health checks are available when the app is running:
+
+```bash
+curl http://localhost:8080/actuator/health
+curl http://localhost:8080/actuator/health/readiness
+```
+
+## Boundaries
+
+- Future REST controllers, request/response DTOs, validation, and API error
+  handling conventions should live with their owning feature packages and reuse
+  shared support under `com.presstronic.academy.api.platform.rest`.
+- Future WebSocket configuration and shared handler support belongs under
+  `com.presstronic.academy.api.platform.websocket`; concrete events,
+  authorization, retries, and fallbacks require focused workflow proposals.
+- Application-owned configuration should use type-safe
+  `@ConfigurationProperties` classes under
+  `com.presstronic.academy.api.platform.config`.
+- Persistence, migrations, generated contracts, local infrastructure, worker
+  jobs, gateway behavior, service extraction, and GraphQL are deferred to
+  separate accepted proposals.

--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    java
+    id("org.springframework.boot") version "3.5.3"
+    id("io.spring.dependency-management") version "1.1.7"
+}
+
+group = "com.presstronic.academy"
+version = "0.1.0-SNAPSHOT"
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/apps/api/settings.gradle.kts
+++ b/apps/api/settings.gradle.kts
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "presstronic-academy-api"

--- a/apps/api/src/main/java/com/presstronic/academy/api/AcademyApiApplication.java
+++ b/apps/api/src/main/java/com/presstronic/academy/api/AcademyApiApplication.java
@@ -1,0 +1,14 @@
+package com.presstronic.academy.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+public class AcademyApiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AcademyApiApplication.class, args);
+    }
+}

--- a/apps/api/src/main/java/com/presstronic/academy/api/platform/config/AcademyApiProperties.java
+++ b/apps/api/src/main/java/com/presstronic/academy/api/platform/config/AcademyApiProperties.java
@@ -1,0 +1,7 @@
+package com.presstronic.academy.api.platform.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "academy.api")
+public record AcademyApiProperties(String applicationName) {
+}

--- a/apps/api/src/main/java/com/presstronic/academy/api/platform/config/package-info.java
+++ b/apps/api/src/main/java/com/presstronic/academy/api/platform/config/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Scaffold-level API configuration.
+ *
+ * <p>Application-owned settings should use type-safe configuration properties
+ * instead of direct environment lookups in feature code.
+ */
+package com.presstronic.academy.api.platform.config;

--- a/apps/api/src/main/java/com/presstronic/academy/api/platform/rest/package-info.java
+++ b/apps/api/src/main/java/com/presstronic/academy/api/platform/rest/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Shared REST conventions for future controllers, DTOs, validation, and API
+ * error responses.
+ *
+ * <p>Feature-specific endpoints should live with their owning feature package
+ * and use this package only for reusable REST support.
+ */
+package com.presstronic.academy.api.platform.rest;

--- a/apps/api/src/main/java/com/presstronic/academy/api/platform/websocket/package-info.java
+++ b/apps/api/src/main/java/com/presstronic/academy/api/platform/websocket/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Shared WebSocket configuration boundary for future live workflows.
+ *
+ * <p>Connection lifecycle, event contracts, authorization, retries, and
+ * fallback behavior are deferred until a focused workflow proposal accepts
+ * those product semantics.
+ */
+package com.presstronic.academy.api.platform.websocket;

--- a/apps/api/src/main/resources/application-local.yml
+++ b/apps/api/src/main/resources/application-local.yml
@@ -1,0 +1,12 @@
+spring:
+  application:
+    name: presstronic-academy-api-local
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  application:
+    name: presstronic-academy-api
+
+academy:
+  api:
+    application-name: Presstronic Academy API
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health,info

--- a/apps/api/src/test/java/com/presstronic/academy/api/AcademyApiApplicationTests.java
+++ b/apps/api/src/test/java/com/presstronic/academy/api/AcademyApiApplicationTests.java
@@ -1,0 +1,20 @@
+package com.presstronic.academy.api;
+
+import com.presstronic.academy.api.platform.config.AcademyApiProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class AcademyApiApplicationTests {
+
+    @Autowired
+    private AcademyApiProperties properties;
+
+    @Test
+    void contextLoadsWithTypedConfiguration() {
+        assertThat(properties.applicationName()).isEqualTo("Presstronic Academy API");
+    }
+}

--- a/docs/openspec-follow-up-proposals.md
+++ b/docs/openspec-follow-up-proposals.md
@@ -28,12 +28,12 @@ and `academy-mvp-scope`.
    - Establish strict TypeScript, Vite, Tailwind CSS, ShadCN, linting, formatting, and workspace scripts.
    - Depends on `academy-monorepo-structure` and should reference `academy-mvp-scope`.
 
-6. `scaffold-spring-boot-api` (next)
+6. `scaffold-spring-boot-api` (accepted)
    - Create the primary `apps/api` Spring Boot application.
    - Establish REST/WebSocket-ready backend structure, health checks, test setup, and local profile conventions.
    - Depends on `academy-monorepo-structure` and should reference `academy-mvp-scope`.
 
-7. `setup-shared-api-contracts`
+7. `setup-shared-api-contracts` (next)
    - Create the initial `packages/contracts` structure for OpenAPI documents, shared schemas, and generated TypeScript clients.
    - Define how frontend clients consume generated contracts.
    - Depends on `scaffold-spring-boot-api` for initial API shape or may run in parallel if using contract-first stubs.
@@ -57,6 +57,6 @@ and `academy-mvp-scope`.
 
 ## First Implementation Recommendation
 
-Start with `scaffold-spring-boot-api`.
+Start with `setup-shared-api-contracts`.
 
-Reason: `academy-frontend-workspaces` will define the frontend application scaffolding. Spring Boot API scaffolding should come next so the primary REST/WebSocket backend boundary exists before shared contracts and local infrastructure are implemented.
+Reason: `academy-spring-boot-api` will establish the primary REST/WebSocket backend scaffold. Shared API contracts should come next so frontend clients and future backend feature work can align on OpenAPI documents, shared schemas, and generated TypeScript client boundaries before product endpoints expand.

--- a/openspec/changes/scaffold-spring-boot-api/tasks.md
+++ b/openspec/changes/scaffold-spring-boot-api/tasks.md
@@ -1,41 +1,41 @@
 ## 1. Repository and Build Setup
 
-- [ ] 1.1 Replace the `apps/api` placeholder with a Spring Boot application scaffold using Gradle Kotlin DSL.
-- [ ] 1.2 Add backend build metadata needed for Java, Spring Boot, dependency management, tests, and application packaging.
-- [ ] 1.3 Wire root-level or documented commands so contributors can run API build and tests from the project root.
-- [ ] 1.4 Keep `apps/worker`, `apps/gateway`, `packages/contracts`, `services/*`, and `infra/*` placeholder-only unless a separate accepted proposal activates them.
+- [x] 1.1 Replace the `apps/api` placeholder with a Spring Boot application scaffold using Gradle Kotlin DSL.
+- [x] 1.2 Add backend build metadata needed for Java, Spring Boot, dependency management, tests, and application packaging.
+- [x] 1.3 Wire root-level or documented commands so contributors can run API build and tests from the project root.
+- [x] 1.4 Keep `apps/worker`, `apps/gateway`, `packages/contracts`, `services/*`, and `infra/*` placeholder-only unless a separate accepted proposal activates them.
 
 ## 2. Application Source Scaffold
 
-- [ ] 2.1 Create the main Spring Boot application entry point under an Academy-owned Java package.
-- [ ] 2.2 Establish feature/domain-oriented package guidance for future REST, WebSocket, auth, and orchestration code.
-- [ ] 2.3 Add minimal scaffold documentation for `apps/api`, including local run, build, test, and health-check commands.
-- [ ] 2.4 Avoid adding learner, admin, content, Code Prompt, Delivery, mentor, billing, or content health product endpoints in this scaffold.
+- [x] 2.1 Create the main Spring Boot application entry point under an Academy-owned Java package.
+- [x] 2.2 Establish feature/domain-oriented package guidance for future REST, WebSocket, auth, and orchestration code.
+- [x] 2.3 Add minimal scaffold documentation for `apps/api`, including local run, build, test, and health-check commands.
+- [x] 2.4 Avoid adding learner, admin, content, Code Prompt, Delivery, mentor, billing, or content health product endpoints in this scaffold.
 
 ## 3. Runtime Configuration and Observability
 
-- [ ] 3.1 Add local/development configuration conventions without committing secrets or production assumptions.
-- [ ] 3.2 Add or document type-safe configuration boundaries for future application-owned settings.
-- [ ] 3.3 Provide a minimal health/readiness surface that verifies scaffold runtime availability.
-- [ ] 3.4 Ensure health/readiness does not require PostgreSQL, Redis, S3, queues, AI providers, billing providers, or code execution systems before those integrations are accepted.
+- [x] 3.1 Add local/development configuration conventions without committing secrets or production assumptions.
+- [x] 3.2 Add or document type-safe configuration boundaries for future application-owned settings.
+- [x] 3.3 Provide a minimal health/readiness surface that verifies scaffold runtime availability.
+- [x] 3.4 Ensure health/readiness does not require PostgreSQL, Redis, S3, queues, AI providers, billing providers, or code execution systems before those integrations are accepted.
 
 ## 4. REST and WebSocket Readiness
 
-- [ ] 4.1 Document where future REST controllers, DTOs, validation, and API error handling conventions will live.
-- [ ] 4.2 Add only scaffold-level REST behavior needed for runtime verification, if any.
-- [ ] 4.3 Document where future WebSocket configuration and handlers will live.
-- [ ] 4.4 Defer WebSocket event contracts, connection authorization, retries, and fallback behavior to future workflow proposals.
+- [x] 4.1 Document where future REST controllers, DTOs, validation, and API error handling conventions will live.
+- [x] 4.2 Add only scaffold-level REST behavior needed for runtime verification, if any.
+- [x] 4.3 Document where future WebSocket configuration and handlers will live.
+- [x] 4.4 Defer WebSocket event contracts, connection authorization, retries, and fallback behavior to future workflow proposals.
 
 ## 5. Testing and Verification
 
-- [ ] 5.1 Add a scaffold test that verifies the Spring application context or equivalent backend bootstrap.
-- [ ] 5.2 Run the API build command.
-- [ ] 5.3 Run the API test command.
-- [ ] 5.4 Run `openspec validate scaffold-spring-boot-api --strict`.
-- [ ] 5.5 Run `openspec validate --all --strict`.
-- [ ] 5.6 Run `git diff --check`.
+- [x] 5.1 Add a scaffold test that verifies the Spring application context or equivalent backend bootstrap.
+- [x] 5.2 Run the API build command.
+- [x] 5.3 Run the API test command.
+- [x] 5.4 Run `openspec validate scaffold-spring-boot-api --strict`.
+- [x] 5.5 Run `openspec validate --all --strict`.
+- [x] 5.6 Run `git diff --check`.
 
 ## 6. Follow-Up Boundaries
 
-- [ ] 6.1 Identify `setup-shared-api-contracts` as the next proposal candidate after Spring Boot API scaffolding is accepted and applied.
-- [ ] 6.2 Confirm persistence, migrations, generated clients, local infrastructure, worker jobs, gateway behavior, microservice extraction, and GraphQL remain deferred.
+- [x] 6.1 Identify `setup-shared-api-contracts` as the next proposal candidate after Spring Boot API scaffolding is accepted and applied.
+- [x] 6.2 Confirm persistence, migrations, generated clients, local infrastructure, worker jobs, gateway behavior, microservice extraction, and GraphQL remain deferred.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "check": "pnpm -r --if-present check",
     "build": "pnpm -r --if-present build",
     "test": "pnpm -r --if-present test",
-    "lint": "pnpm -r --if-present lint"
+    "lint": "pnpm -r --if-present lint",
+    "api:build": "gradle -p apps/api build",
+    "api:test": "gradle -p apps/api test",
+    "api:bootRun": "gradle -p apps/api bootRun --args='--spring.profiles.active=local'"
   }
 }


### PR DESCRIPTION
## Summary
- Implements the accepted `scaffold-spring-boot-api` OpenSpec change.
- Adds a buildable Spring Boot API scaffold under `apps/api` using Gradle Kotlin DSL and Java 21.
- Adds actuator health/readiness configuration, local profile conventions, typed configuration scaffolding, REST/WebSocket package boundaries, and a context-load test.
- Adds root API commands and updates API docs plus the follow-up roadmap to `setup-shared-api-contracts` next.
- Keeps persistence, contracts, infra, workers, gateway, services, product APIs, and GraphQL deferred.

## Verification
- `pnpm api:test`
- `pnpm api:build`
- `openspec validate scaffold-spring-boot-api --strict`
- `openspec validate --all --strict`
- `git diff --check`

Note: Initial parallel `api:build`/`api:test` run had a Gradle XML test-results write conflict because both commands wrote the same test report concurrently. Rerunning sequentially passed.