### PR TITLE
docs: capture remaining OpenSpec roadmap

### DIFF
--- a/docs/openspec-follow-up-proposals.md
+++ b/docs/openspec-follow-up-proposals.md
@@ -33,26 +33,26 @@ and `academy-mvp-scope`.
    - Establish REST/WebSocket-ready backend structure, health checks, test setup, and local profile conventions.
    - Depends on `academy-monorepo-structure` and should reference `academy-mvp-scope`.
 
-7. `setup-shared-api-contracts` (next)
+7. `setup-shared-api-contracts` (proposed)
    - Create the initial `packages/contracts` structure for OpenAPI documents, shared schemas, and generated TypeScript clients.
    - Define how frontend clients consume generated contracts.
    - Depends on `scaffold-spring-boot-api` for initial API shape or may run in parallel if using contract-first stubs.
 
-8. `setup-local-development-infrastructure`
+8. `setup-local-development-infrastructure` (proposed)
    - Define Docker Compose services for PostgreSQL, Redis, S3-compatible storage, and local app wiring.
    - Establish environment file conventions without committing secrets.
    - Depends on the initial API and frontend scaffold decisions.
 
 9. Future service activation proposals
-   - `activate-code-runner-service`
-   - `activate-notifications-service`
-   - `activate-billing-service`
+   - `activate-code-runner-service` (proposed)
+   - `activate-notifications-service` (proposed)
+   - `activate-billing-service` (proposed)
    - Each service remains placeholder-only until its proposal defines deployment, data, contracts, observability, and failure behavior.
 
 10. Future/B2B proposals
-   - `define-academy-hiring-assessments`
-   - `define-academy-candidate-review-packets`
-   - `define-academy-company-prompt-libraries`
+   - `define-academy-hiring-assessments` (proposed)
+   - `define-academy-candidate-review-packets` (proposed)
+   - `define-academy-company-prompt-libraries` (proposed)
    - These remain future/B2B until the learner Code Prompt and Delivery loop is proven.
 
 ## First Implementation Recommendation
@@ -60,3 +60,16 @@ and `academy-mvp-scope`.
 Start with `setup-shared-api-contracts`.
 
 Reason: `academy-spring-boot-api` will establish the primary REST/WebSocket backend scaffold. Shared API contracts should come next so frontend clients and future backend feature work can align on OpenAPI documents, shared schemas, and generated TypeScript client boundaries before product endpoints expand.
+
+## Captured Active Changes
+
+The remaining roadmap items are captured as OpenSpec changes:
+
+- `setup-shared-api-contracts`
+- `setup-local-development-infrastructure`
+- `activate-code-runner-service`
+- `activate-notifications-service`
+- `activate-billing-service`
+- `define-academy-hiring-assessments`
+- `define-academy-candidate-review-packets`
+- `define-academy-company-prompt-libraries`

--- a/openspec/changes/activate-billing-service/.openspec.yaml
+++ b/openspec/changes/activate-billing-service/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/activate-billing-service/design.md
+++ b/openspec/changes/activate-billing-service/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The MVP can use limited invite or billing/access gating, while full billing lifecycle work remains broader than the first learner loop. A billing service boundary should define when provider isolation and entitlement synchronization justify service activation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define `services/billing` ownership for billing provider integration.
+- Separate access gating decisions from provider-specific webhook handling.
+- Define entitlement synchronization and failure visibility.
+- Preserve future compliance and audit boundaries.
+
+**Non-Goals:**
+
+- Do not select a provider or implement checkout.
+- Do not define final pricing.
+- Do not implement subscription lifecycle, invoices, refunds, or tax behavior.
+- Do not make billing service required for invite-only MVP access.
+
+## Decisions
+
+### Decision: Keep billing service future-oriented until provider complexity exists
+
+Billing service extraction is justified by provider isolation, compliance, webhooks, and entitlement synchronization. Basic access gating can remain in the primary app boundary until those needs are accepted.
+
+Alternative considered: activate billing service immediately. That would add operational complexity before the learner loop proves value.
+
+### Decision: Entitlements are the integration contract
+
+Application access should depend on normalized entitlements rather than direct provider status checks scattered across features.
+
+Alternative considered: let feature code query provider state directly. That couples product behavior to provider APIs and failure modes.
+
+## Risks / Trade-offs
+
+- Premature extraction can slow MVP -> keep service future/B2B or launch-gating scoped until needed.
+- Provider webhook failures can desync access -> require idempotency, replay, and audit trails.
+- Entitlement bugs can block learners -> define safe failure and support visibility.
+- Compliance scope can expand -> keep sensitive provider data isolated.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Define entitlement and provider webhook contracts.
+3. Implement service scaffold only when billing provider integration is accepted.
+4. Wire access checks through normalized entitlements rather than provider-specific calls.
+
+## Open Questions
+
+- Which billing provider should be used first?
+- Does MVP launch require paid access, invite-only access, or both?
+- Where should entitlement records live before a dedicated billing service is active?

--- a/openspec/changes/activate-billing-service/proposal.md
+++ b/openspec/changes/activate-billing-service/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Billing and entitlement behavior is important for access control, but full billing service extraction should not happen accidentally inside the primary API. The service boundary needs a proposal before provider webhooks, entitlement synchronization, or compliance-sensitive billing workflows are implemented.
+
+## What Changes
+
+- Define `services/billing` as the future owner for provider integration, entitlement synchronization, billing webhooks, and billing observability.
+- Clarify how billing service behavior relates to existing limited billing/access gating.
+- Keep production provider selection, pricing, payment collection, and subscription lifecycle implementation deferred.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-billing-service`: Billing service boundary, provider webhooks, entitlement synchronization, access gating integration, compliance boundaries, and observability.
+
+### Modified Capabilities
+
+- `academy-monorepo-structure`: Activates `services/billing` only after provider and entitlement boundaries are accepted.
+- `academy-billing-access`: Clarifies the future split between basic access gating and extracted billing service behavior.
+
+## Impact
+
+- Affects future files under `services/billing`, API contracts, entitlement data, and billing provider integration.
+- Does not implement production billing, pricing, checkout, subscription management, or provider webhooks.

--- a/openspec/changes/activate-billing-service/specs/academy-billing-access/spec.md
+++ b/openspec/changes/activate-billing-service/specs/academy-billing-access/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Billing Service Access Split
+The billing access capability SHALL allow future billing service integration through normalized entitlements while preserving simple invite or access gating before full billing is accepted.
+
+#### Scenario: Access gating consumes entitlement state
+GIVEN billing service behavior is accepted
+WHEN Academy access decisions require paid or subscription state
+THEN access gating consumes normalized entitlement state
+AND does not depend on provider-specific billing payloads in learner or admin app workflows.
+
+#### Scenario: MVP access can remain simple
+GIVEN full billing service activation is not required for MVP launch
+WHEN access gating is implemented
+THEN invite-only or simple access controls may proceed without activating checkout, subscription lifecycle, or provider webhook behavior.

--- a/openspec/changes/activate-billing-service/specs/academy-billing-service/spec.md
+++ b/openspec/changes/activate-billing-service/specs/academy-billing-service/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Billing Service Boundary
+The system SHALL treat `services/billing` as the independently deployable boundary for billing provider integration once provider isolation or entitlement synchronization requires service activation.
+
+#### Scenario: Billing service owns provider integration
+GIVEN billing service activation is implemented
+WHEN billing provider behavior is reviewed
+THEN provider webhooks, provider API calls, billing event normalization, and entitlement synchronization live under `services/billing`
+AND product apps consume normalized access state rather than provider-specific payloads.
+
+### Requirement: Entitlement Synchronization
+The billing service SHALL synchronize provider billing state into Academy entitlement state used by access decisions.
+
+#### Scenario: Entitlement state changes
+GIVEN a billing provider event changes account access
+WHEN the event is processed
+THEN Academy entitlement state is updated through an idempotent flow
+AND the resulting access state can be audited.
+
+#### Scenario: Provider state is unavailable
+GIVEN the billing provider is unavailable or returns an error
+WHEN entitlement synchronization runs
+THEN the failure is recorded
+AND access behavior follows documented safe failure rules.
+
+### Requirement: Billing Webhook Handling
+The billing service SHALL define webhook validation, idempotency, replay, and failure behavior before production provider webhooks are enabled.
+
+#### Scenario: Webhook is verified
+GIVEN a provider webhook is received
+WHEN the service processes the event
+THEN authenticity is verified before side effects occur
+AND duplicate events do not create duplicate entitlement changes.
+
+### Requirement: Billing Observability
+The billing service SHALL provide visibility into provider events, entitlement changes, failed synchronizations, and access-impacting errors.
+
+#### Scenario: Billing health is reviewed
+GIVEN billing integration is active
+WHEN operators inspect billing health
+THEN webhook failures, replay needs, provider API failures, and entitlement update outcomes are visible.

--- a/openspec/changes/activate-billing-service/specs/academy-monorepo-structure/spec.md
+++ b/openspec/changes/activate-billing-service/specs/academy-monorepo-structure/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Billing Service Activation
+The monorepo structure capability SHALL allow `services/billing` to become active only through an accepted proposal that defines provider, entitlement, webhook, compliance, and observability boundaries.
+
+#### Scenario: Billing service becomes active
+GIVEN `activate-billing-service` is accepted and applied
+WHEN billing provider behavior is implemented
+THEN `services/billing` becomes the active owner for provider integration and entitlement synchronization
+AND app workspaces consume accepted entitlement contracts.

--- a/openspec/changes/activate-billing-service/tasks.md
+++ b/openspec/changes/activate-billing-service/tasks.md
@@ -1,0 +1,21 @@
+## 1. Service Boundary
+
+- [ ] 1.1 Replace placeholder-only `services/billing` documentation with active service boundary documentation.
+- [ ] 1.2 Define service package/build/runtime metadata.
+- [ ] 1.3 Document ownership between access gating, provider integration, and entitlement synchronization.
+- [ ] 1.4 Keep checkout, pricing, production provider credentials, and subscription lifecycle implementation deferred.
+
+## 2. Billing Contracts
+
+- [ ] 2.1 Define entitlement synchronization concepts and states.
+- [ ] 2.2 Define provider webhook handling, idempotency, replay, and audit expectations.
+- [ ] 2.3 Define failure handling when provider state and Academy state diverge.
+- [ ] 2.4 Define observability requirements for billing events and entitlement changes.
+
+## 3. Verification
+
+- [ ] 3.1 Run service scaffold build or equivalent checks.
+- [ ] 3.2 Run contract/schema checks if added.
+- [ ] 3.3 Run `openspec validate activate-billing-service --strict`.
+- [ ] 3.4 Run `openspec validate --all --strict`.
+- [ ] 3.5 Run `git diff --check`.

--- a/openspec/changes/activate-code-runner-service/.openspec.yaml
+++ b/openspec/changes/activate-code-runner-service/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/activate-code-runner-service/design.md
+++ b/openspec/changes/activate-code-runner-service/design.md
@@ -1,0 +1,59 @@
+## Context
+
+Code execution is core to the first shippable learner loop, but it is also a high-risk boundary. The primary API can orchestrate requests, but untrusted code execution needs explicit isolation, lifecycle, and observability decisions before implementation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the service ownership boundary for isolated code execution.
+- Define job states and result semantics that Delivery evaluation can consume.
+- Require sandbox isolation, resource limits, timeout behavior, and artifact controls.
+- Preserve observability and failure handling as first-class requirements.
+
+**Non-Goals:**
+
+- Do not choose a sandbox technology in this proposal.
+- Do not implement execution, queues, persistence, or deployment.
+- Do not define all language/runtime images.
+- Do not make code-runner output the only source of Delivery acceptance.
+
+## Decisions
+
+### Decision: Treat code execution as an independently deployable service
+
+Untrusted execution has different scaling, security, and operational needs than the primary API. `services/code-runner` should activate only when those needs are accepted.
+
+Alternative considered: run code inside `apps/api`. That would reduce initial moving parts but would mix high-risk execution with request handling.
+
+### Decision: Use explicit job lifecycle states
+
+Evaluation consumers need stable states such as queued, running, succeeded, failed, timed out, and canceled before they can present reliable feedback.
+
+Alternative considered: return raw process results only. That would make user-facing feedback and retries inconsistent.
+
+### Decision: Keep sandbox technology deferred
+
+The proposal should define the safety contract before locking the exact runtime provider.
+
+Alternative considered: choose Docker, Firecracker, or a managed runner now. That is premature before workload and isolation needs are validated.
+
+## Risks / Trade-offs
+
+- Sandbox escapes or resource abuse -> require isolation, resource limits, and no shared secrets in execution environments.
+- Long-running jobs can overload the system -> require timeouts, queue limits, and cancellation semantics.
+- Result semantics can overclaim correctness -> code-runner reports execution/evaluation results, while Delivery acceptance remains product-owned.
+- Artifact retention can leak data -> require retention and redaction rules before artifacts are stored.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Define contracts between API/worker and code-runner.
+3. Implement a minimal runner scaffold with safe no-op or controlled execution behavior.
+4. Add real sandbox execution only after runtime technology is selected and verified.
+
+## Open Questions
+
+- Which sandbox/runtime provider should be used first?
+- Should job orchestration live in `apps/api`, `apps/worker`, or both?
+- Which programming languages are supported in the first runner?

--- a/openspec/changes/activate-code-runner-service/proposal.md
+++ b/openspec/changes/activate-code-runner-service/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The Academy learner loop depends on realistic code execution and Delivery evaluation, but isolated execution should not be improvised inside the primary API. The code-runner service boundary needs an accepted contract before implementation touches sandboxing, job lifecycle, or evaluation behavior.
+
+## What Changes
+
+- Define `services/code-runner` as the future independently deployable home for isolated code execution.
+- Specify job submission, sandbox isolation, artifact handling, result reporting, failure states, and observability boundaries.
+- Clarify how Code Prompts and Deliveries may depend on execution results once the service is accepted.
+- Keep implementation, provider selection, persistence schemas, and production scaling deferred.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-code-runner-service`: Isolated code execution service boundary, job lifecycle, sandboxing, artifacts, result semantics, observability, and failure handling.
+
+### Modified Capabilities
+
+- `academy-monorepo-structure`: Activates `services/code-runner` only after isolation and operational boundaries are accepted.
+- `academy-code-prompts-deliveries`: Clarifies how Delivery evaluation may consume code-runner results.
+
+## Impact
+
+- Affects future files under `services/code-runner`, API contracts, worker orchestration, and Delivery evaluation flows.
+- May introduce sandbox/runtime dependencies in a later implementation step.
+- Does not implement the service, execute code, create persistence schemas, or accept Deliveries automatically.

--- a/openspec/changes/activate-code-runner-service/specs/academy-code-prompts-deliveries/spec.md
+++ b/openspec/changes/activate-code-runner-service/specs/academy-code-prompts-deliveries/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Delivery Evaluation Runner Integration
+The Code Prompts and Deliveries capability SHALL allow Delivery evaluation to consume accepted code-runner job results without making runner output the sole owner of product acceptance.
+
+#### Scenario: Delivery consumes run results
+GIVEN a Delivery requires automated execution or tests
+WHEN code-runner results are available
+THEN the Delivery evaluation can reference job state, test output, execution metadata, and failure categories
+AND presents safe feedback to the learner or reviewer.
+
+#### Scenario: Acceptance remains product-owned
+GIVEN a code-runner job succeeds
+WHEN Delivery acceptance is determined
+THEN acceptance may consider runner results, rubric checks, manual review, and prompt requirements
+AND runner success alone does not imply product acceptance unless the prompt evaluation contract explicitly says so.

--- a/openspec/changes/activate-code-runner-service/specs/academy-code-runner-service/spec.md
+++ b/openspec/changes/activate-code-runner-service/specs/academy-code-runner-service/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Code Runner Service Boundary
+The system SHALL treat `services/code-runner` as the independently deployable boundary for isolated code execution once the service is accepted.
+
+#### Scenario: Service boundary is active
+GIVEN code-runner service activation is implemented
+WHEN repository ownership is reviewed
+THEN isolated execution behavior lives under `services/code-runner`
+AND primary API or worker code only orchestrates accepted runner contracts.
+
+#### Scenario: Primary API does not execute untrusted code
+GIVEN learner or candidate code must run
+WHEN the execution path is reviewed
+THEN untrusted code is not executed inside the primary API request process
+AND execution is delegated to the accepted runner boundary.
+
+### Requirement: Execution Job Lifecycle
+The code-runner service SHALL expose explicit job lifecycle states for execution and evaluation work.
+
+#### Scenario: Job states are observable
+GIVEN a run job is submitted
+WHEN its status is queried or reported
+THEN the job reports a stable lifecycle state such as queued, running, succeeded, failed, timed out, or canceled
+AND consumers do not need to infer state from raw process output.
+
+#### Scenario: Failure states preserve feedback
+GIVEN a job fails or times out
+WHEN results are returned
+THEN the response distinguishes infrastructure failure, timeout, evaluation failure, and invalid input where feasible
+AND includes safe feedback suitable for learner or reviewer surfaces.
+
+### Requirement: Sandbox Isolation
+The code-runner service SHALL execute untrusted code in a sandboxed environment with explicit resource, network, secret, and filesystem boundaries.
+
+#### Scenario: Resource limits are enforced
+GIVEN a job runs untrusted code
+WHEN execution begins
+THEN CPU, memory, wall-clock time, process, and filesystem limits are enforced according to the accepted runner configuration.
+
+#### Scenario: Secrets are not exposed
+GIVEN a runner environment is prepared
+WHEN untrusted code executes
+THEN production secrets and unrelated service credentials are not present in the execution environment.
+
+### Requirement: Runner Result Artifacts
+The code-runner service SHALL define how logs, test output, generated artifacts, and evaluation metadata are returned or retained.
+
+#### Scenario: Safe output is returned
+GIVEN execution produces logs or test output
+WHEN the result is delivered to Academy systems
+THEN output is bounded, sanitized where needed, and associated with the run job
+AND oversized or unsafe output is handled predictably.
+
+#### Scenario: Retention remains explicit
+GIVEN execution artifacts need storage
+WHEN artifact retention is implemented
+THEN retention duration, access rules, and deletion behavior are documented
+AND storage layout is not implied solely by the runner service scaffold.
+
+### Requirement: Runner Observability
+The code-runner service SHALL provide operational visibility for job volume, duration, failures, timeouts, and sandbox health.
+
+#### Scenario: Runner health is observable
+GIVEN the runner service is deployed or run locally
+WHEN operators inspect service health
+THEN health and readiness signals distinguish service availability from individual job success.
+
+#### Scenario: Job metrics are captured
+GIVEN jobs are processed
+WHEN observability is reviewed
+THEN job counts, durations, failure categories, timeout counts, and queue pressure are available or intentionally deferred with documented rationale.

--- a/openspec/changes/activate-code-runner-service/specs/academy-monorepo-structure/spec.md
+++ b/openspec/changes/activate-code-runner-service/specs/academy-monorepo-structure/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Code Runner Service Activation
+The monorepo structure capability SHALL allow `services/code-runner` to become active only through an accepted proposal that defines isolation, contracts, observability, and failure behavior.
+
+#### Scenario: Code runner service becomes active
+GIVEN `activate-code-runner-service` is accepted and applied
+WHEN code execution behavior is implemented
+THEN `services/code-runner` becomes the active owner for isolated execution
+AND app workspaces only orchestrate or consume its accepted contracts.
+
+#### Scenario: Runner activation does not activate other services
+GIVEN `services/code-runner` is active
+WHEN `services/notifications`, `services/billing`, `apps/gateway`, or unrelated service directories are reviewed
+THEN those areas remain inactive unless their own proposals are accepted.

--- a/openspec/changes/activate-code-runner-service/tasks.md
+++ b/openspec/changes/activate-code-runner-service/tasks.md
@@ -1,0 +1,27 @@
+## 1. Service Boundary
+
+- [ ] 1.1 Replace placeholder-only `services/code-runner` documentation with active service boundary documentation.
+- [ ] 1.2 Define service package/build/runtime metadata.
+- [ ] 1.3 Document ownership between `apps/api`, `apps/worker`, and `services/code-runner`.
+- [ ] 1.4 Keep unrelated services inactive.
+
+## 2. Execution Contract
+
+- [ ] 2.1 Define job request and result contract shape.
+- [ ] 2.2 Define job lifecycle states and failure semantics.
+- [ ] 2.3 Define sandbox isolation, timeout, resource, and cancellation requirements.
+- [ ] 2.4 Define artifact and log handling boundaries.
+
+## 3. Evaluation Integration
+
+- [ ] 3.1 Document how Delivery evaluation consumes code-runner results.
+- [ ] 3.2 Ensure code-runner output does not automatically imply Delivery acceptance.
+- [ ] 3.3 Keep persistence schemas and production queue wiring deferred unless separately accepted.
+
+## 4. Verification
+
+- [ ] 4.1 Run service scaffold build or equivalent checks.
+- [ ] 4.2 Run contract/schema checks if added.
+- [ ] 4.3 Run `openspec validate activate-code-runner-service --strict`.
+- [ ] 4.4 Run `openspec validate --all --strict`.
+- [ ] 4.5 Run `git diff --check`.

--- a/openspec/changes/activate-notifications-service/.openspec.yaml
+++ b/openspec/changes/activate-notifications-service/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/activate-notifications-service/design.md
+++ b/openspec/changes/activate-notifications-service/design.md
@@ -1,0 +1,53 @@
+## Context
+
+Notifications cut across learner, admin, content, billing, and operations workflows. Without a service boundary, notification behavior can become scattered across product features and provider-specific APIs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define notification ownership and delivery lifecycle.
+- Separate product event sources from delivery provider concerns.
+- Support future email, in-app, and operational channels.
+- Require preferences, retries, idempotency, and observability before production sending.
+
+**Non-Goals:**
+
+- Do not choose or wire a production provider.
+- Do not define marketing campaigns or broad lifecycle messaging.
+- Do not implement notification UI.
+- Do not activate billing or code-runner service behavior.
+
+## Decisions
+
+### Decision: Centralize delivery in `services/notifications`
+
+Notification delivery has provider, retry, template, preference, and observability concerns that should not be duplicated across feature modules.
+
+Alternative considered: send notifications directly from `apps/api`. That is acceptable for early prototypes but does not scale across delivery guarantees and provider failure modes.
+
+### Decision: Product events remain source-owned
+
+Feature areas should own whether an event matters; the notification service owns how accepted messages are delivered.
+
+Alternative considered: let the notification service infer product meaning. That would couple delivery infrastructure to product workflows.
+
+## Risks / Trade-offs
+
+- Overbuilding before message volume exists -> start with service boundaries and minimal delivery contracts.
+- Provider lock-in -> keep provider-specific configuration behind service-owned adapters.
+- Duplicate notifications -> require idempotency keys and delivery state.
+- User trust issues -> require preference and suppression boundaries.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Define message and delivery contracts.
+3. Scaffold notification service without production provider credentials.
+4. Add provider integration only when first notification workflow is accepted.
+
+## Open Questions
+
+- Which channel should ship first: email, in-app, or operational webhook?
+- Should notification preferences live in the primary API data model or notification service data model?
+- Should templates be source-owned files, database records, or admin-managed content?

--- a/openspec/changes/activate-notifications-service/proposal.md
+++ b/openspec/changes/activate-notifications-service/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Academy workflows will eventually need notifications for Delivery review, learner support, admin operations, billing events, and long-running job status. Notification delivery should have an accepted boundary before provider-specific behavior or background workflows are implemented.
+
+## What Changes
+
+- Define `services/notifications` as the future owner for notification delivery and provider integration.
+- Specify notification sources, channels, templates, preferences, delivery states, retries, and observability.
+- Keep real provider wiring, marketing automation, and broad lifecycle messaging deferred.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-notifications-service`: Notification delivery service boundary, source events, channels, preferences, templates, delivery lifecycle, retries, and observability.
+
+### Modified Capabilities
+
+- `academy-monorepo-structure`: Activates `services/notifications` only after delivery and provider boundaries are accepted.
+
+## Impact
+
+- Affects future files under `services/notifications`, worker orchestration, and API contracts.
+- May add email/provider dependencies in a later implementation step.
+- Does not implement provider credentials, marketing campaigns, or production notification sending.

--- a/openspec/changes/activate-notifications-service/specs/academy-monorepo-structure/spec.md
+++ b/openspec/changes/activate-notifications-service/specs/academy-monorepo-structure/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Notifications Service Activation
+The monorepo structure capability SHALL allow `services/notifications` to become active only through an accepted proposal that defines delivery, provider, preference, retry, and observability boundaries.
+
+#### Scenario: Notifications service becomes active
+GIVEN `activate-notifications-service` is accepted and applied
+WHEN notification delivery behavior is implemented
+THEN `services/notifications` becomes the active owner for provider sending and delivery lifecycle
+AND product features only request notifications through accepted contracts.

--- a/openspec/changes/activate-notifications-service/specs/academy-notifications-service/spec.md
+++ b/openspec/changes/activate-notifications-service/specs/academy-notifications-service/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Notifications Service Boundary
+The system SHALL treat `services/notifications` as the independently deployable boundary for notification delivery once the service is accepted.
+
+#### Scenario: Service owns delivery
+GIVEN notification behavior is implemented
+WHEN delivery ownership is reviewed
+THEN provider integration, delivery state, retries, templates, and channel-specific sending live under the notifications boundary
+AND product features remain responsible for deciding which events require notification.
+
+### Requirement: Notification Delivery Lifecycle
+The notifications service SHALL track delivery lifecycle states and retry behavior for outbound notifications.
+
+#### Scenario: Delivery state is observable
+GIVEN a notification is requested
+WHEN delivery is processed
+THEN the system can distinguish pending, sent, failed, suppressed, and retryable states
+AND failures are observable for operational review.
+
+#### Scenario: Duplicate delivery is controlled
+GIVEN the same product event is processed more than once
+WHEN notification delivery is requested
+THEN idempotency or deduplication prevents unintended duplicate sends where the notification contract requires it.
+
+### Requirement: Notification Channels and Templates
+The notifications service SHALL define supported channels and template ownership before production sending is enabled.
+
+#### Scenario: Channel is accepted before use
+GIVEN a workflow needs email, in-app, webhook, or other delivery
+WHEN notification behavior is implemented
+THEN the channel is explicitly supported by the service contract
+AND unsupported channels are not used implicitly by feature code.
+
+#### Scenario: Template ownership is clear
+GIVEN a notification requires authored content
+WHEN templates are implemented
+THEN template source, variables, fallback behavior, and review ownership are documented.
+
+### Requirement: Notification Preferences and Suppression
+The notifications service SHALL respect user or account notification preferences and operational suppression rules where applicable.
+
+#### Scenario: Preference check occurs before send
+GIVEN a notification targets a learner, admin, instructor, candidate, or company user
+WHEN delivery is attempted
+THEN applicable preference and suppression rules are evaluated before provider sending.
+
+### Requirement: Notification Observability
+The notifications service SHALL provide visibility into delivery volume, provider errors, retries, suppressions, and latency.
+
+#### Scenario: Delivery health is reviewed
+GIVEN notification sending is active
+WHEN operators inspect notification health
+THEN delivery attempts, failures, retry counts, suppression counts, and provider error categories are visible or intentionally deferred with documented rationale.

--- a/openspec/changes/activate-notifications-service/tasks.md
+++ b/openspec/changes/activate-notifications-service/tasks.md
@@ -1,0 +1,21 @@
+## 1. Service Boundary
+
+- [ ] 1.1 Replace placeholder-only `services/notifications` documentation with active service boundary documentation.
+- [ ] 1.2 Define service package/build/runtime metadata.
+- [ ] 1.3 Document ownership between product event sources, worker orchestration, and notification delivery.
+- [ ] 1.4 Keep provider credentials and production sending disabled until accepted.
+
+## 2. Delivery Model
+
+- [ ] 2.1 Define notification source event and delivery request shapes.
+- [ ] 2.2 Define delivery lifecycle states, retries, idempotency, and failure handling.
+- [ ] 2.3 Define channel, template, preference, and suppression boundaries.
+- [ ] 2.4 Define observability requirements for delivery attempts and failures.
+
+## 3. Verification
+
+- [ ] 3.1 Run service scaffold build or equivalent checks.
+- [ ] 3.2 Run contract/schema checks if added.
+- [ ] 3.3 Run `openspec validate activate-notifications-service --strict`.
+- [ ] 3.4 Run `openspec validate --all --strict`.
+- [ ] 3.5 Run `git diff --check`.

--- a/openspec/changes/define-academy-candidate-review-packets/.openspec.yaml
+++ b/openspec/changes/define-academy-candidate-review-packets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/define-academy-candidate-review-packets/design.md
+++ b/openspec/changes/define-academy-candidate-review-packets/design.md
@@ -1,0 +1,52 @@
+## Context
+
+Hiring assessments produce evidence that company reviewers need to understand quickly. Review packets should curate candidate work and evaluation context without exposing unnecessary learner/candidate data or raw operational details.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define packet ownership and contents.
+- Establish derived evidence, redaction, sharing, expiration, and audit boundaries.
+- Keep packet access distinct from learner profile and admin content access.
+
+**Non-Goals:**
+
+- Do not implement packet generation.
+- Do not implement company reviewer UI.
+- Do not define hiring decision automation.
+- Do not activate hiring assessments themselves in this change.
+
+## Decisions
+
+### Decision: Packets are derived artifacts
+
+Review packets should be generated from assessment attempts, Deliveries, rubrics, and evaluation results rather than becoming the source of truth for assessment data.
+
+Alternative considered: store review packet as the primary assessment record. That would make revisions, redactions, and audits harder.
+
+### Decision: Access and expiration are required
+
+Candidate review packets can contain sensitive work evidence, so access, sharing, expiration, and audit behavior need to be part of the spec before implementation.
+
+Alternative considered: treat packets as ordinary admin reports. That does not fit candidate privacy or company sharing needs.
+
+## Risks / Trade-offs
+
+- Packets can overexpose candidate data -> require redaction and scoped access.
+- Derived summaries can misrepresent evidence -> preserve source references and reviewer context.
+- Sharing links can leak -> require expiration and audit requirements.
+- Review packets can become broad reporting -> keep scope tied to assessment evidence.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Implement only after hiring assessments provide source attempts and Deliveries.
+3. Add packet generation and sharing flows through focused implementation.
+4. Validate packet content against privacy and access requirements.
+
+## Open Questions
+
+- Should packets be exportable as PDF, web-only, or both?
+- How long should packets remain accessible by default?
+- Which packet fields should candidates be able to inspect or dispute?

--- a/openspec/changes/define-academy-candidate-review-packets/proposal.md
+++ b/openspec/changes/define-academy-candidate-review-packets/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Candidate review packets are a future/B2B assessment output that needs its own boundary before companies can consume assessment evidence. Capturing it now keeps review artifacts separate from learner progress, raw Delivery data, and admin content operations.
+
+## What Changes
+
+- Define candidate review packet contents, evidence sources, reviewer-facing summaries, access rules, and sharing lifecycle.
+- Clarify that review packets are derived from accepted assessment attempts and Deliveries.
+- Define privacy, redaction, audit, expiration, and export boundaries.
+- Keep implementation deferred until hiring assessments are accepted and built.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-candidate-review-packets`: Future/B2B candidate packet generation, contents, evidence mapping, sharing lifecycle, redaction, access, and audit behavior.
+
+### Modified Capabilities
+
+- `academy-mvp-scope`: Clarifies that candidate review packets remain future/B2B and do not ship in the first learner MVP.
+
+## Impact
+
+- Affects future assessment review surfaces, company reviewer access, exports, and evidence retention.
+- Does not implement packet generation, exports, company reviewer UI, or assessment workflows.

--- a/openspec/changes/define-academy-candidate-review-packets/specs/academy-candidate-review-packets/spec.md
+++ b/openspec/changes/define-academy-candidate-review-packets/specs/academy-candidate-review-packets/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Candidate Review Packet Boundary
+The system SHALL treat candidate review packets as future/B2B derived artifacts for assessment review rather than source-of-truth learner or assessment records.
+
+#### Scenario: Packet is derived from assessment evidence
+GIVEN a candidate assessment has evaluation evidence
+WHEN a review packet is generated
+THEN the packet derives from candidate attempts, Deliveries, rubric results, reviewer notes, and evaluation metadata
+AND does not replace the underlying assessment records.
+
+### Requirement: Packet Contents
+Candidate review packets SHALL include only accepted evidence fields needed for company review.
+
+#### Scenario: Reviewer inspects packet
+GIVEN a company reviewer opens a packet
+WHEN packet contents are displayed
+THEN the packet includes candidate identity context, assessment prompt context, submitted work evidence, evaluation outcomes, rubric mapping, and reviewer notes where accepted
+AND excludes private learner data that is not part of the assessment review contract.
+
+### Requirement: Packet Sharing Lifecycle
+Candidate review packets SHALL define sharing, expiration, revocation, and audit behavior before company access is implemented.
+
+#### Scenario: Packet access is shared
+GIVEN a packet is made available to a company reviewer
+WHEN access is granted
+THEN the access has documented scope and expiration behavior
+AND packet views or exports are auditable.
+
+#### Scenario: Packet access is revoked
+GIVEN packet access should no longer be available
+WHEN access is revoked or expires
+THEN company reviewers can no longer view the packet through that grant
+AND the revocation or expiration is recorded.
+
+### Requirement: Packet Redaction
+Candidate review packets SHALL support redaction or exclusion of sensitive evidence before sharing.
+
+#### Scenario: Sensitive evidence is excluded
+GIVEN assessment evidence contains data not approved for company review
+WHEN packet content is prepared
+THEN unapproved fields are redacted or excluded
+AND the packet still references enough source context for review integrity.

--- a/openspec/changes/define-academy-candidate-review-packets/specs/academy-mvp-scope/spec.md
+++ b/openspec/changes/define-academy-candidate-review-packets/specs/academy-mvp-scope/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Future Candidate Review Packet Deferral
+The MVP scope SHALL defer candidate review packet generation and company sharing until future/B2B assessment workflows are accepted.
+
+#### Scenario: Packet work is requested during MVP
+GIVEN candidate review packets are proposed during learner MVP implementation
+WHEN MVP scope is enforced
+THEN packet generation, sharing, exports, company reviewer access, and packet audit remain future/B2B
+AND do not block the first learner delivery loop.

--- a/openspec/changes/define-academy-candidate-review-packets/tasks.md
+++ b/openspec/changes/define-academy-candidate-review-packets/tasks.md
@@ -1,0 +1,19 @@
+## 1. Packet Domain Boundary
+
+- [ ] 1.1 Define candidate review packet source data and derived artifact ownership.
+- [ ] 1.2 Define packet contents, evidence summaries, rubric mapping, and source references.
+- [ ] 1.3 Define sharing lifecycle, expiration, and revocation behavior.
+- [ ] 1.4 Keep packet generation and reviewer UI implementation deferred.
+
+## 2. Privacy and Audit
+
+- [ ] 2.1 Define redaction and candidate privacy boundaries.
+- [ ] 2.2 Define company reviewer access rules.
+- [ ] 2.3 Define packet audit events.
+- [ ] 2.4 Define export boundaries without implementing export formats.
+
+## 3. Verification
+
+- [ ] 3.1 Run `openspec validate define-academy-candidate-review-packets --strict`.
+- [ ] 3.2 Run `openspec validate --all --strict`.
+- [ ] 3.3 Run `git diff --check`.

--- a/openspec/changes/define-academy-company-prompt-libraries/.openspec.yaml
+++ b/openspec/changes/define-academy-company-prompt-libraries/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/define-academy-company-prompt-libraries/design.md
+++ b/openspec/changes/define-academy-company-prompt-libraries/design.md
@@ -1,0 +1,53 @@
+## Context
+
+Academy learning content and future company assessment prompts share prompt structure, but they have different ownership, visibility, review, and lifecycle needs. Company prompt libraries should be captured as future/B2B before tenant-specific content is implemented.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define company-owned prompt library boundaries.
+- Preserve reuse of Code Prompt structure where appropriate.
+- Establish versioning, governance, visibility, and assignment eligibility.
+- Keep company content separate from Academy learner curriculum.
+
+**Non-Goals:**
+
+- Do not implement company prompt authoring.
+- Do not implement tenant administration.
+- Do not implement assessment assignment or candidate delivery.
+- Do not define final import/export formats.
+
+## Decisions
+
+### Decision: Company prompts reuse Code Prompt structure
+
+Shared prompt shape keeps future B2B prompts compatible with Delivery and evaluation systems.
+
+Alternative considered: create a fully separate company prompt model. That would duplicate prompt and Delivery foundations too early.
+
+### Decision: Company prompt visibility is tenant-scoped
+
+Company prompts should not appear in public Academy catalog or learner curriculum unless explicitly promoted through a later workflow.
+
+Alternative considered: store all prompts in one global library. That risks content leakage and ownership confusion.
+
+## Risks / Trade-offs
+
+- Tenant content can leak into learner surfaces -> require visibility boundaries.
+- Company prompts can drift from evaluable structures -> preserve Code Prompt compatibility.
+- Versioning can become complex -> require version snapshots before assignment.
+- Imports can bring unsafe content -> require validation and review before use.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Implement only after B2B assessment workflows are accepted.
+3. Add company prompt library storage, review, and assignment behavior through focused changes.
+4. Keep Academy learner curriculum separate unless explicit promotion is accepted.
+
+## Open Questions
+
+- Should company prompt libraries support private templates, shared templates, or both?
+- Who can review and approve company prompts before assignment?
+- Should company prompts be exportable or importable in OpenAPI/JSON/YAML formats?

--- a/openspec/changes/define-academy-company-prompt-libraries/proposal.md
+++ b/openspec/changes/define-academy-company-prompt-libraries/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Company prompt libraries are a future/B2B capability that can reuse Code Prompt foundations, but tenant-specific prompt ownership should not leak into MVP content authoring. Capturing the boundary now keeps company content, assessment prompts, and Academy learning content separate.
+
+## What Changes
+
+- Define company-owned prompt libraries, tenant prompt visibility, assignment eligibility, review status, and versioning.
+- Clarify how company prompts may reuse Code Prompt structures while staying separate from Academy learner curriculum.
+- Define governance, ownership, privacy, import/export, and lifecycle boundaries.
+- Keep implementation deferred until B2B assessment workflows are accepted.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-company-prompt-libraries`: Future/B2B company-owned prompt libraries, prompt lifecycle, visibility, versioning, governance, and assignment boundaries.
+
+### Modified Capabilities
+
+- `academy-mvp-scope`: Clarifies that company prompt libraries remain future/B2B and do not ship in the first learner MVP.
+
+## Impact
+
+- Affects future B2B admin workflows, prompt authoring, assessment assignment, tenancy, and content governance.
+- Does not implement tenant administration, prompt library UI, imports, exports, or company-specific assessment delivery.

--- a/openspec/changes/define-academy-company-prompt-libraries/specs/academy-company-prompt-libraries/spec.md
+++ b/openspec/changes/define-academy-company-prompt-libraries/specs/academy-company-prompt-libraries/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Company Prompt Library Boundary
+The system SHALL treat company prompt libraries as future/B2B tenant-owned prompt collections that remain separate from Academy learner curriculum.
+
+#### Scenario: Company prompt remains tenant-scoped
+GIVEN a company prompt exists
+WHEN prompt visibility is reviewed
+THEN the prompt is visible only to authorized company or Academy roles according to tenant access rules
+AND does not appear in learner catalog or Academy curriculum unless a later promotion workflow is accepted.
+
+### Requirement: Code Prompt Compatibility
+Company prompts SHALL reuse the accepted Code Prompt foundation where practical while adding company-specific ownership and assignment constraints.
+
+#### Scenario: Company prompt is assigned
+GIVEN a company prompt is used for an assessment
+WHEN candidate work is requested
+THEN the prompt can provide mission brief, objective, constraints, starter instructions, delivery checklist, and evaluation expectations
+AND company-specific ownership and visibility rules are preserved.
+
+### Requirement: Company Prompt Lifecycle
+Company prompt libraries SHALL define draft, review, approved, archived, and assigned lifecycle boundaries before implementation.
+
+#### Scenario: Prompt version is assigned
+GIVEN a company prompt is assigned to candidates
+WHEN the assignment is created
+THEN a stable prompt version or snapshot is used
+AND later prompt edits do not silently alter existing candidate assignments.
+
+#### Scenario: Prompt is archived
+GIVEN a company prompt should no longer be assigned
+WHEN the prompt is archived
+THEN it is unavailable for new assignments
+AND existing assessment records retain the version used.
+
+### Requirement: Company Prompt Governance
+Company prompt libraries SHALL define ownership, review, validation, and import/export boundaries before tenant content workflows are implemented.
+
+#### Scenario: Prompt requires review
+GIVEN a company prompt is created or imported
+WHEN it becomes eligible for assignment
+THEN validation and review requirements are satisfied according to company prompt governance
+AND unsafe or incomplete prompts are not assignable.

--- a/openspec/changes/define-academy-company-prompt-libraries/specs/academy-mvp-scope/spec.md
+++ b/openspec/changes/define-academy-company-prompt-libraries/specs/academy-mvp-scope/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Future Company Prompt Library Deferral
+The MVP scope SHALL defer company-owned prompt libraries until future/B2B assessment workflows are accepted.
+
+#### Scenario: Company prompt libraries are requested during MVP
+GIVEN company-owned prompt libraries, tenant prompts, imports, exports, or company assignment templates are proposed during learner MVP implementation
+WHEN MVP scope is enforced
+THEN those capabilities remain future/B2B
+AND do not block Academy learner curriculum or first learner Delivery loop implementation.

--- a/openspec/changes/define-academy-company-prompt-libraries/tasks.md
+++ b/openspec/changes/define-academy-company-prompt-libraries/tasks.md
@@ -1,0 +1,19 @@
+## 1. Library Domain Boundary
+
+- [ ] 1.1 Define company prompt library, company prompt, version, owner, reviewer, and assignment eligibility concepts.
+- [ ] 1.2 Document how company prompts reuse Code Prompt foundations.
+- [ ] 1.3 Define tenant visibility and Academy curriculum separation.
+- [ ] 1.4 Keep prompt library implementation, imports, exports, and tenant administration deferred.
+
+## 2. Governance and Lifecycle
+
+- [ ] 2.1 Define draft, review, approved, archived, and assigned prompt states.
+- [ ] 2.2 Define version snapshot behavior for assessment assignment.
+- [ ] 2.3 Define ownership, access, and sharing rules.
+- [ ] 2.4 Define validation boundaries for imported or copied prompts.
+
+## 3. Verification
+
+- [ ] 3.1 Run `openspec validate define-academy-company-prompt-libraries --strict`.
+- [ ] 3.2 Run `openspec validate --all --strict`.
+- [ ] 3.3 Run `git diff --check`.

--- a/openspec/changes/define-academy-hiring-assessments/.openspec.yaml
+++ b/openspec/changes/define-academy-hiring-assessments/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/define-academy-hiring-assessments/design.md
+++ b/openspec/changes/define-academy-hiring-assessments/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The accepted MVP scope classifies hiring assessments as future/B2B. Assessments can share Code Prompt, Delivery, evaluation, and evidence concepts, but they introduce company ownership, candidate privacy, rubric integrity, review packets, and tenant-specific prompts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the future assessment boundary without implementing it.
+- Preserve compatibility with learner Code Prompts and Deliveries.
+- Identify privacy, integrity, and review constraints.
+- Separate candidate assessment flows from learner education flows.
+
+**Non-Goals:**
+
+- Do not implement assessments in MVP.
+- Do not define company billing, tenant administration, or final pricing.
+- Do not implement anti-cheating or plagiarism detection.
+- Do not implement candidate review packets or company prompt libraries in this change.
+
+## Decisions
+
+### Decision: Reuse Code Prompt and Delivery concepts
+
+Assessments should build on the same work-submission foundation as learning, with assessment-specific ownership and constraints.
+
+Alternative considered: create a separate assessment work model. That would duplicate the strongest shared foundation before there is evidence it needs to diverge.
+
+### Decision: Keep candidate privacy separate from learner profile
+
+Candidate assessment evidence should not automatically become learner profile or public portfolio evidence.
+
+Alternative considered: treat candidates as learners. That would blur privacy, consent, and review expectations.
+
+## Risks / Trade-offs
+
+- Assessment needs can distort MVP learning -> keep implementation deferred and scoped as future/B2B.
+- Candidate privacy requirements are higher -> require consent and access boundaries before implementation.
+- Anti-cheating can become a broad product -> capture integrity boundaries without overcommitting implementation.
+- Rubric complexity can grow quickly -> define minimum rubric concepts before building editors.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Preserve MVP Code Prompt and Delivery compatibility.
+3. Later define candidate review packets and company prompt libraries as separate future/B2B changes.
+4. Implement assessment workflows only after the learner delivery loop is proven.
+
+## Open Questions
+
+- Should candidates authenticate through the same auth surface as learners?
+- What evidence can be shared with companies, candidates, and internal reviewers?
+- Which integrity controls are required before a paid B2B assessment launch?

--- a/openspec/changes/define-academy-hiring-assessments/proposal.md
+++ b/openspec/changes/define-academy-hiring-assessments/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Hiring assessments are a future/B2B direction that should reuse the Academy Code Prompt and Delivery foundation without leaking into the learner MVP. Capturing the boundary now preserves compatibility while keeping implementation deferred.
+
+## What Changes
+
+- Define future hiring assessment concepts: company assignment, candidate attempt, rubric, evaluation, reviewer access, and assessment outcome.
+- Clarify how assessments reuse Code Prompt and Delivery foundations.
+- Establish anti-cheating, candidate privacy, time-window, and review integrity boundaries.
+- Keep B2B implementation, tenant administration, pricing, and production assessment workflows deferred.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-hiring-assessments`: Future/B2B assessment assignments, candidate attempts, rubrics, evaluation boundaries, integrity controls, and privacy constraints.
+
+### Modified Capabilities
+
+- `academy-mvp-scope`: Clarifies that hiring assessments remain future/B2B while preserving compatibility with MVP Code Prompt and Delivery design.
+
+## Impact
+
+- Affects future B2B product specs, contracts, admin workflows, and Delivery evaluation.
+- Does not implement candidate-facing assessment UI, company tenancy, reviewer workflows, anti-cheating systems, or paid B2B packaging.

--- a/openspec/changes/define-academy-hiring-assessments/specs/academy-hiring-assessments/spec.md
+++ b/openspec/changes/define-academy-hiring-assessments/specs/academy-hiring-assessments/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Hiring Assessment Boundary
+The system SHALL treat hiring assessments as a future/B2B capability that reuses Code Prompt and Delivery foundations without becoming part of the first learner MVP.
+
+#### Scenario: Assessment remains future/B2B
+GIVEN hiring assessment behavior is proposed
+WHEN MVP scope is enforced
+THEN assessment workflows remain future/B2B
+AND do not block the first shippable learner loop.
+
+#### Scenario: Assessment reuses work foundation
+GIVEN a hiring assessment includes practical engineering work
+WHEN a candidate submits work
+THEN the assessment can reuse Code Prompt, Delivery, attempt, evaluation, and evidence concepts
+AND assessment-specific ownership, privacy, and review constraints are applied.
+
+### Requirement: Candidate Attempt
+The hiring assessment capability SHALL model candidate attempts separately from learner progress.
+
+#### Scenario: Candidate attempt is recorded
+GIVEN a candidate starts an assessment
+WHEN the attempt is created
+THEN it is associated with an assessment assignment, candidate identity, prompt or task set, time constraints, and submission state
+AND it does not automatically update learner progression.
+
+### Requirement: Assessment Rubric
+The hiring assessment capability SHALL define rubric-based evaluation boundaries before assessment review is implemented.
+
+#### Scenario: Rubric guides evaluation
+GIVEN a candidate Delivery is reviewed
+WHEN an assessment rubric is available
+THEN reviewer feedback and automated checks can map to rubric criteria
+AND final recommendation remains distinguishable from raw test results.
+
+### Requirement: Assessment Privacy and Integrity
+The hiring assessment capability SHALL define candidate privacy, consent, access, and integrity boundaries before production assessment workflows are implemented.
+
+#### Scenario: Candidate evidence access is controlled
+GIVEN assessment evidence exists
+WHEN a company reviewer, candidate, or Academy operator accesses it
+THEN access follows assessment-specific permissions and consent rules
+AND evidence is not exposed as public learner profile data by default.
+
+#### Scenario: Integrity controls are explicit
+GIVEN anti-cheating, plagiarism detection, monitoring, or time-window enforcement is implemented
+WHEN integrity behavior is reviewed
+THEN the controls are explicitly specified by assessment proposals
+AND are not implied solely by learner Delivery behavior.

--- a/openspec/changes/define-academy-hiring-assessments/specs/academy-mvp-scope/spec.md
+++ b/openspec/changes/define-academy-hiring-assessments/specs/academy-mvp-scope/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Future Hiring Assessment Compatibility
+The MVP scope SHALL preserve compatibility with future hiring assessments without implementing assessment workflows in the learner MVP.
+
+#### Scenario: MVP Delivery design preserves assessment compatibility
+GIVEN Code Prompt or Delivery behavior is implemented for learners
+WHEN future assessment needs are considered
+THEN the design avoids blocking later assessment assignments, candidate attempts, rubrics, and review packets
+AND does not implement hiring workflows before a future/B2B proposal is accepted.
+
+#### Scenario: Assessment work remains deferred
+GIVEN hiring assessment features are requested during MVP work
+WHEN MVP scope is enforced
+THEN the features remain future/B2B unless a later proposal explicitly changes scope.

--- a/openspec/changes/define-academy-hiring-assessments/tasks.md
+++ b/openspec/changes/define-academy-hiring-assessments/tasks.md
@@ -1,0 +1,19 @@
+## 1. Assessment Domain Boundary
+
+- [ ] 1.1 Define assessment assignment, candidate attempt, rubric, evaluation, reviewer, and outcome concepts.
+- [ ] 1.2 Document how assessment work reuses Code Prompt and Delivery foundations.
+- [ ] 1.3 Separate candidate assessment state from learner progress and public evidence.
+- [ ] 1.4 Keep tenant administration, billing, and production workflows deferred.
+
+## 2. Integrity and Privacy
+
+- [ ] 2.1 Define candidate consent and data access boundaries.
+- [ ] 2.2 Define time-window and attempt constraints.
+- [ ] 2.3 Define anti-cheating and plagiarism detection boundaries without implementing them.
+- [ ] 2.4 Define rubric visibility and reviewer access constraints.
+
+## 3. Verification
+
+- [ ] 3.1 Run `openspec validate define-academy-hiring-assessments --strict`.
+- [ ] 3.2 Run `openspec validate --all --strict`.
+- [ ] 3.3 Run `git diff --check`.

--- a/openspec/changes/setup-local-development-infrastructure/.openspec.yaml
+++ b/openspec/changes/setup-local-development-infrastructure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/setup-local-development-infrastructure/design.md
+++ b/openspec/changes/setup-local-development-infrastructure/design.md
@@ -1,0 +1,60 @@
+## Context
+
+PostgreSQL, Redis, and S3-compatible storage are expected infrastructure for the Academy direction, but the repository has not yet activated local service wiring. Local infrastructure should be predictable before persistence-backed features and job workflows are implemented.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a local Docker Compose environment for core development dependencies.
+- Establish `.env` template conventions without committing secrets.
+- Provide documented start, stop, health, and reset commands.
+- Keep app configuration explicit and local-profile scoped.
+
+**Non-Goals:**
+
+- Do not define production deployment topology.
+- Do not create feature database schemas or migrations.
+- Do not wire real AI, billing, email, or code execution providers.
+- Do not activate independent services beyond local dependencies.
+
+## Decisions
+
+### Decision: Keep local infrastructure under `infra/`
+
+`infra/` is the accepted owner for infrastructure assets. Local Compose files and bootstrap scripts should live there or be clearly referenced from there.
+
+Alternative considered: put Compose configuration at root only. Root commands can delegate, but infrastructure ownership should stay clear.
+
+### Decision: Use templates for environment files
+
+Environment templates document required values while keeping developer-specific values out of git.
+
+Alternative considered: commit working `.env` files. That risks secret leakage and makes local setup less explicit.
+
+### Decision: Defer schema-specific setup
+
+The local database can exist before feature schemas do. Schema migrations should arrive with persistence or feature proposals.
+
+Alternative considered: create broad starter schemas now. That would prematurely lock data shape before product workflows are implemented.
+
+## Risks / Trade-offs
+
+- Compose can drift from production -> label it local-only and defer production infrastructure.
+- Local reset commands can delete data -> document destructive commands clearly.
+- Service ports can conflict -> document defaults and override paths.
+- App wiring can imply feature readiness -> keep readiness checks limited to accepted dependencies.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Add local infrastructure files and environment templates.
+3. Document startup, shutdown, health, and reset workflows.
+4. Wire API local profile only to accepted local dependencies.
+5. Add verification that local config parses without requiring production secrets.
+
+## Open Questions
+
+- Which S3-compatible local service should be used first?
+- Should local infrastructure include a database admin UI, or defer it?
+- Should app processes be included in Compose, or should Compose only run dependencies?

--- a/openspec/changes/setup-local-development-infrastructure/proposal.md
+++ b/openspec/changes/setup-local-development-infrastructure/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The app and API scaffolds are active, but local infrastructure remains placeholder-only. Before persistence, Redis-backed workflows, object storage, or integration-heavy features are implemented, contributors need an accepted local environment contract.
+
+## What Changes
+
+- Define local development infrastructure for PostgreSQL, Redis, S3-compatible storage, and app wiring.
+- Establish environment file conventions without committing secrets.
+- Define health, readiness, reset, and documentation expectations for local services.
+- Keep production deployment, cloud provisioning, CI environments, and feature persistence schemas out of scope.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-local-development-infrastructure`: Local Docker Compose services, environment conventions, service health, reset behavior, and app wiring boundaries.
+
+### Modified Capabilities
+
+- `academy-monorepo-structure`: Activates local infrastructure assets under `infra/` without implying production deployment.
+- `academy-spring-boot-api`: Clarifies how the API may consume local infrastructure configuration after the local environment is accepted.
+
+## Impact
+
+- Affects future files under `infra/`, root documentation, `.env` templates, and local app configuration.
+- May affect `apps/api` local profile conventions and root scripts.
+- Does not implement database schemas, migrations, production secrets, cloud infrastructure, or feature-specific service integrations.

--- a/openspec/changes/setup-local-development-infrastructure/specs/academy-local-development-infrastructure/spec.md
+++ b/openspec/changes/setup-local-development-infrastructure/specs/academy-local-development-infrastructure/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Local Infrastructure Environment
+The repository SHALL define a local development infrastructure environment for dependencies required by accepted Academy application work.
+
+#### Scenario: Local dependencies are declared
+GIVEN local infrastructure is implemented
+WHEN a contributor reviews the local environment
+THEN PostgreSQL, Redis, and S3-compatible storage are declared or intentionally deferred
+AND each active local dependency has documented purpose, port, credentials, and health behavior.
+
+#### Scenario: Local infrastructure is not production deployment
+GIVEN local Compose or scripts exist
+WHEN deployment behavior is reviewed
+THEN local infrastructure is identified as development-only
+AND production provisioning remains deferred to deployment or infrastructure proposals.
+
+### Requirement: Environment File Conventions
+The repository SHALL document environment values through templates without committing developer secrets or production credentials.
+
+#### Scenario: Environment templates exist
+GIVEN local setup requires environment variables
+WHEN a contributor prepares their environment
+THEN committed templates identify required variable names and safe defaults
+AND local secret-bearing files remain ignored.
+
+#### Scenario: Production secrets remain absent
+GIVEN production credentials are required later
+WHEN local infrastructure is implemented
+THEN production secrets and provider credentials are not committed
+AND production secret management remains deferred.
+
+### Requirement: Local Service Operations
+The repository SHALL document routine local infrastructure commands for startup, shutdown, health checks, logs, and reset behavior.
+
+#### Scenario: Contributor starts local dependencies
+GIVEN local infrastructure is implemented
+WHEN a contributor follows documented startup commands
+THEN required local dependencies start with predictable names and ports
+AND health checks indicate when they are ready for app use.
+
+#### Scenario: Reset commands are explicit
+GIVEN local reset behavior is documented
+WHEN a command deletes volumes, buckets, queues, or cached data
+THEN the documentation marks the operation as destructive
+AND does not run destructive reset as part of routine checks.
+
+### Requirement: App Wiring Boundaries
+Local infrastructure SHALL support accepted local application wiring without implying unaccepted feature schemas, queues, storage layouts, or integrations.
+
+#### Scenario: API local profile consumes accepted dependencies
+GIVEN local infrastructure is active
+WHEN `apps/api` local configuration references local dependencies
+THEN the references are scoped to local or development profiles
+AND production configuration remains externalized.
+
+#### Scenario: Feature persistence remains deferred
+GIVEN database, cache, or object storage exists locally
+WHEN feature-specific storage behavior is reviewed
+THEN schemas, migrations, queue topics, object layouts, and retention rules remain deferred until focused proposals accept them.

--- a/openspec/changes/setup-local-development-infrastructure/specs/academy-monorepo-structure/spec.md
+++ b/openspec/changes/setup-local-development-infrastructure/specs/academy-monorepo-structure/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Local Infrastructure Activation
+The monorepo structure capability SHALL allow accepted local infrastructure work to activate development-only assets under `infra/` while preserving production deployment and service ownership boundaries.
+
+#### Scenario: Local infrastructure assets are active
+GIVEN `setup-local-development-infrastructure` is accepted and applied
+WHEN local infrastructure files are created
+THEN they live under `infra/` or root scripts that delegate to `infra/`
+AND they are documented as development-only assets.
+
+#### Scenario: Local infrastructure does not activate services
+GIVEN local dependency containers exist
+WHEN `services/*`, `apps/worker`, or `apps/gateway` are reviewed
+THEN they remain inactive unless separately accepted
+AND local dependency containers are not treated as Academy service implementations.

--- a/openspec/changes/setup-local-development-infrastructure/specs/academy-spring-boot-api/spec.md
+++ b/openspec/changes/setup-local-development-infrastructure/specs/academy-spring-boot-api/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: API Local Infrastructure Configuration
+The Spring Boot API capability SHALL allow local-profile configuration for accepted local infrastructure dependencies without committing production assumptions.
+
+#### Scenario: Local profile references development dependencies
+GIVEN local infrastructure has been accepted
+WHEN `apps/api` runs with a local profile
+THEN it may reference local PostgreSQL, Redis, or S3-compatible endpoints
+AND those values are externalized or documented through safe local defaults.
+
+#### Scenario: Local dependencies do not imply feature readiness
+GIVEN local PostgreSQL, Redis, or object storage is available
+WHEN API product behavior is reviewed
+THEN feature schemas, repositories, queues, object layouts, and integration behavior still require focused proposals before implementation.

--- a/openspec/changes/setup-local-development-infrastructure/tasks.md
+++ b/openspec/changes/setup-local-development-infrastructure/tasks.md
@@ -1,0 +1,28 @@
+## 1. Local Service Definition
+
+- [ ] 1.1 Define local PostgreSQL service configuration.
+- [ ] 1.2 Define local Redis service configuration.
+- [ ] 1.3 Define local S3-compatible storage configuration.
+- [ ] 1.4 Keep provider-specific production integrations absent.
+
+## 2. Environment and Documentation
+
+- [ ] 2.1 Add environment template files without committing secrets.
+- [ ] 2.2 Document service ports, credentials, override points, and startup order.
+- [ ] 2.3 Document start, stop, health, logs, and reset commands.
+- [ ] 2.4 Identify which commands are destructive before documenting reset behavior.
+
+## 3. App Wiring Boundaries
+
+- [ ] 3.1 Update API local profile conventions only where local dependencies are accepted.
+- [ ] 3.2 Avoid adding feature schemas, migrations, queues, or object layouts before focused proposals accept them.
+- [ ] 3.3 Keep frontend apps independent of local infrastructure except through accepted API/client boundaries.
+
+## 4. Verification
+
+- [ ] 4.1 Validate Docker Compose configuration.
+- [ ] 4.2 Verify documented local service health checks.
+- [ ] 4.3 Run affected app configuration checks.
+- [ ] 4.4 Run `openspec validate setup-local-development-infrastructure --strict`.
+- [ ] 4.5 Run `openspec validate --all --strict`.
+- [ ] 4.6 Run `git diff --check`.

--- a/openspec/changes/setup-shared-api-contracts/.openspec.yaml
+++ b/openspec/changes/setup-shared-api-contracts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/setup-shared-api-contracts/design.md
+++ b/openspec/changes/setup-shared-api-contracts/design.md
@@ -1,0 +1,60 @@
+## Context
+
+`apps/api` is now the primary Spring Boot API workspace, and `apps/web` plus `apps/admin` are active React workspaces. `packages/contracts` remains placeholder-only. Without a shared contract package, frontend code can grow around handwritten fetch shapes while backend APIs grow independently.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish `packages/contracts` as the shared API contract workspace.
+- Define where OpenAPI documents, shared schemas, and generated TypeScript clients live.
+- Make contract validation and client generation repeatable from root commands.
+- Preserve backend ownership of endpoint behavior and frontend ownership of app workflows.
+- Keep initial contracts scaffold-level until feature endpoint proposals accept concrete API behavior.
+
+**Non-Goals:**
+
+- Do not implement learner, admin, billing, mentor, content health, Code Prompt, or Delivery endpoints.
+- Do not define database schemas or persistence migrations.
+- Do not introduce GraphQL.
+- Do not activate service-specific contracts before the related service proposals are accepted.
+
+## Decisions
+
+### Decision: Use OpenAPI as the REST contract source
+
+REST remains the default API style in the accepted monorepo spec. OpenAPI gives a durable contract format for backend verification, frontend client generation, and reviewer-friendly schema diffs.
+
+Alternative considered: handwritten TypeScript-only client types. That would help frontend development but would not give backend or external contract validation a neutral source.
+
+### Decision: Keep generated clients inside `packages/contracts`
+
+Generated TypeScript clients should live beside the contract source so frontend apps consume one workspace package instead of committing generated code into each app.
+
+Alternative considered: generate clients directly into `apps/web` and `apps/admin`. That would duplicate generated artifacts and make contract changes harder to review.
+
+### Decision: Keep product endpoint contracts deferred
+
+The initial contracts package should prove tooling and ownership without inventing product APIs ahead of feature specs.
+
+Alternative considered: define all first-pass product endpoints now. That would mix scaffolding with product workflow decisions that deserve focused proposals.
+
+## Risks / Trade-offs
+
+- Contract tooling can become heavy before endpoints exist -> start with minimal validation/generation commands.
+- Generated clients can obscure API semantics -> keep OpenAPI documents source-owned and reviewable.
+- Contract-first work can block feature flow if too rigid -> allow feature proposals to add focused contract deltas.
+- Backend and frontend versions can drift -> make root verification include contract validation once implemented.
+
+## Migration Plan
+
+1. Accept this proposal.
+2. Scaffold `packages/contracts` with package metadata, OpenAPI source layout, generation output layout, and validation commands.
+3. Add root scripts or documented commands for contract validation/generation.
+4. Use later feature proposals to add concrete endpoint contracts.
+
+## Open Questions
+
+- Which OpenAPI generator should be used for TypeScript clients?
+- Should shared runtime validation use generated schemas immediately, or remain compile-time only until APIs exist?
+- Should the first contract include only health/readiness examples, or no endpoint examples at all?

--- a/openspec/changes/setup-shared-api-contracts/proposal.md
+++ b/openspec/changes/setup-shared-api-contracts/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Frontend and backend scaffolds are now active, but there is still no accepted contract boundary between `apps/api`, frontend clients, and future services. Shared API contracts should be defined before feature APIs expand so REST schemas, generated clients, and validation ownership do not drift.
+
+## What Changes
+
+- Define `packages/contracts` as the source-owned workspace for OpenAPI documents, shared schemas, and generated TypeScript clients.
+- Establish REST contract ownership between Spring Boot endpoint behavior and frontend consumption.
+- Define contract generation, versioning, validation, and documentation expectations.
+- Defer production learner/admin/product endpoints to focused feature proposals.
+- Keep GraphQL, persistence schemas, service extraction, and external integrations out of this setup.
+
+## Capabilities
+
+### New Capabilities
+
+- `academy-api-contracts`: Shared REST/OpenAPI contract source, generated frontend client boundaries, schema validation ownership, versioning, and verification.
+
+### Modified Capabilities
+
+- `academy-monorepo-structure`: Activates `packages/contracts` while preserving app/service ownership boundaries.
+- `academy-spring-boot-api`: Clarifies how the API scaffold relates to contract documents and generated clients.
+
+## Impact
+
+- Affects future files under `packages/contracts`.
+- Affects future backend/frontend API work by requiring contract-first or contract-synced schemas.
+- May add build tooling for OpenAPI validation and TypeScript client generation in a later implementation step.
+- Does not implement production product endpoints, database models, authentication flows, live WebSocket contracts, or GraphQL.

--- a/openspec/changes/setup-shared-api-contracts/specs/academy-api-contracts/spec.md
+++ b/openspec/changes/setup-shared-api-contracts/specs/academy-api-contracts/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Shared API Contract Workspace
+The repository SHALL use `packages/contracts` as the shared workspace for REST API contract source, generated frontend clients, and reusable schema artifacts.
+
+#### Scenario: Contracts workspace exists
+GIVEN shared API contracts are implemented
+WHEN a contributor reviews the workspace layout
+THEN `packages/contracts` contains source-owned API contract documents
+AND contains or documents generated TypeScript client outputs
+AND remains separate from app-specific workflow state.
+
+#### Scenario: Contract source is reviewable
+GIVEN an API contract changes
+WHEN the change is reviewed
+THEN the source contract diff is readable without requiring generated-client diffs as the only evidence.
+
+### Requirement: OpenAPI REST Contract Source
+The contracts workspace SHALL use OpenAPI-compatible documents as the default source of truth for REST endpoint shapes.
+
+#### Scenario: REST contract is specified
+GIVEN a REST endpoint is accepted by a future proposal
+WHEN its request, response, status, or error shape is documented
+THEN the shape is represented in OpenAPI-compatible contract source
+AND backend and frontend implementation can verify against that contract.
+
+#### Scenario: Product endpoints remain deferred
+GIVEN product endpoint behavior has not been accepted
+WHEN the contracts scaffold is implemented
+THEN production learner, admin, billing, mentor, content, Code Prompt, Delivery, and content health endpoint contracts remain absent or placeholder-documented
+AND require focused proposals before implementation.
+
+### Requirement: Generated Frontend Client Boundary
+The contracts workspace SHALL define how generated TypeScript clients are produced and consumed by frontend workspaces.
+
+#### Scenario: Frontend client consumption
+GIVEN generated clients exist
+WHEN `apps/web` or `apps/admin` consumes backend APIs
+THEN they consume the generated client package or documented exports from `packages/contracts`
+AND do not maintain unrelated handwritten request/response types for contracted APIs.
+
+#### Scenario: Generation is repeatable
+GIVEN contract source changes
+WHEN client generation runs
+THEN generated TypeScript output is deterministic
+AND contributors can reproduce it from documented workspace commands.
+
+### Requirement: Contract Verification
+The contracts workspace SHALL provide validation commands for contract syntax, schema consistency, and generated output readiness.
+
+#### Scenario: Contract validation succeeds
+GIVEN contract tooling is installed
+WHEN contract validation runs
+THEN OpenAPI documents are checked for syntax and schema validity
+AND failures report the contract source that needs correction.
+
+#### Scenario: Root verification includes contracts
+GIVEN the contracts workspace is active
+WHEN root quality commands run
+THEN contract validation or checks run where present
+AND contributors do not need to infer contract verification commands.
+
+### Requirement: Contract Ownership Boundaries
+The contracts workspace SHALL define API shapes without owning backend behavior, frontend workflows, persistence schemas, or service implementation.
+
+#### Scenario: Backend behavior remains API-owned
+GIVEN an endpoint contract exists
+WHEN backend behavior is implemented
+THEN controller behavior, authorization, orchestration, and error handling live in `apps/api` or an accepted service boundary
+AND `packages/contracts` remains the contract artifact owner.
+
+#### Scenario: Persistence remains separate
+GIVEN API contracts reference data fields
+WHEN database storage is designed
+THEN persistence schemas and migrations remain owned by persistence or feature proposals
+AND are not implied solely by the API contract.

--- a/openspec/changes/setup-shared-api-contracts/specs/academy-monorepo-structure/spec.md
+++ b/openspec/changes/setup-shared-api-contracts/specs/academy-monorepo-structure/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Shared API Contracts Package Activation
+The monorepo structure capability SHALL allow accepted contract scaffolding to activate `packages/contracts` while preserving application, service, and infrastructure ownership boundaries.
+
+#### Scenario: Contracts placeholder becomes active workspace
+GIVEN `setup-shared-api-contracts` is accepted and applied
+WHEN contract scaffolding is implemented
+THEN `packages/contracts` becomes an active shared workspace
+AND its ownership remains limited to API contracts, generated clients, and shared schema artifacts.
+
+#### Scenario: Contracts do not activate product endpoints
+GIVEN contract scaffolding is implemented
+WHEN learner, admin, Code Prompt, Delivery, billing, mentor, or content health behavior is reviewed
+THEN those product workflows remain owned by focused feature proposals
+AND are not considered implemented by activating `packages/contracts`.

--- a/openspec/changes/setup-shared-api-contracts/specs/academy-spring-boot-api/spec.md
+++ b/openspec/changes/setup-shared-api-contracts/specs/academy-spring-boot-api/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: API Contract Alignment
+The Spring Boot API capability SHALL align future REST endpoint behavior with shared OpenAPI contracts without making generated clients part of backend runtime ownership.
+
+#### Scenario: Endpoint implementation follows accepted contract
+GIVEN a REST endpoint contract has been accepted
+WHEN the endpoint is implemented in `apps/api`
+THEN request, response, status, and error behavior align with the shared contract
+AND contract drift is caught by documented verification.
+
+#### Scenario: Generated clients remain outside API runtime
+GIVEN TypeScript clients are generated from OpenAPI contracts
+WHEN backend application packaging is reviewed
+THEN generated frontend clients live under `packages/contracts`
+AND are not required for the Spring Boot runtime artifact.

--- a/openspec/changes/setup-shared-api-contracts/tasks.md
+++ b/openspec/changes/setup-shared-api-contracts/tasks.md
@@ -1,0 +1,28 @@
+## 1. Contract Workspace Scaffold
+
+- [ ] 1.1 Replace placeholder-only `packages/contracts` documentation with active workspace documentation.
+- [ ] 1.2 Add package metadata for contract source, validation, and generated client outputs.
+- [ ] 1.3 Create an OpenAPI source layout that can hold API-level and feature-level contract files.
+- [ ] 1.4 Create a generated TypeScript client output boundary without committing feature clients before contracts exist.
+
+## 2. Tooling and Scripts
+
+- [ ] 2.1 Add contract validation tooling and workspace scripts.
+- [ ] 2.2 Add client generation tooling or documented generation command.
+- [ ] 2.3 Wire root scripts or documented commands for contract validation and generation.
+- [ ] 2.4 Ensure generated artifacts are deterministic or explicitly ignored when they are derived outputs.
+
+## 3. Integration Boundaries
+
+- [ ] 3.1 Document how `apps/api` keeps endpoint behavior aligned with OpenAPI contracts.
+- [ ] 3.2 Document how `apps/web` and `apps/admin` consume generated clients.
+- [ ] 3.3 Confirm API clients remain deferred for product workflows not yet accepted.
+- [ ] 3.4 Keep persistence, auth, WebSocket event contracts, service contracts, and GraphQL out of this setup.
+
+## 4. Verification
+
+- [ ] 4.1 Run contract validation commands.
+- [ ] 4.2 Run affected workspace build/typecheck commands.
+- [ ] 4.3 Run `openspec validate setup-shared-api-contracts --strict`.
+- [ ] 4.4 Run `openspec validate --all --strict`.
+- [ ] 4.5 Run `git diff --check`.


### PR DESCRIPTION
## Summary

Captures every remaining documented roadmap item as an active OpenSpec change before additional implementation work:

- setup-shared-api-contracts
- setup-local-development-infrastructure
- activate-code-runner-service
- activate-notifications-service
- activate-billing-service
- define-academy-hiring-assessments
- define-academy-candidate-review-packets
- define-academy-company-prompt-libraries

Also updates docs/openspec-follow-up-proposals.md to mark those roadmap items as proposed and list the active change IDs.

## Scope

This is documentation/specification work only. It does not implement app, API, service, infrastructure, billing, assessment, or B2B runtime behavior.

## Validation

- openspec validate setup-shared-api-contracts --strict
- openspec validate setup-local-development-infrastructure --strict
- openspec validate activate-code-runner-service --strict
- openspec validate activate-notifications-service --strict
- openspec validate activate-billing-service --strict
- openspec validate define-academy-hiring-assessments --strict
- openspec validate define-academy-candidate-review-packets --strict
- openspec validate define-academy-company-prompt-libraries --strict
- openspec validate --all --strict
- git diff --check